### PR TITLE
Interactive add plot

### DIFF
--- a/backend/vcdat/app.py
+++ b/backend/vcdat/app.py
@@ -59,7 +59,7 @@ def serve_resource_file(path):
             'MaterialIcons-Regular.ttf',
             'MaterialIcons-Regular.woff',
             'MaterialIcons-Regular.woff2',
-            'add_plot.svg']:
+            '']:
             return send_from_directory(dir_path, 'deps/' + path)
         if path in ['Bundle.js', 'Bundle.js.map']:
             return send_from_directory(dir_path, 'dist/' + path)

--- a/backend/vcdat/app.py
+++ b/backend/vcdat/app.py
@@ -51,6 +51,7 @@ def serve_resource_file(path):
             'clt_image.png',
             'bootstrap-themed.min.css',
             'bootstrap.min.css',
+            'bootstrap.min.css.map',
             'bootstrap.min.js',
             'glyphicons-halflings-regular.woff2',
             'glyphicons-halflings-regular.woff',
@@ -59,7 +60,7 @@ def serve_resource_file(path):
             'MaterialIcons-Regular.ttf',
             'MaterialIcons-Regular.woff',
             'MaterialIcons-Regular.woff2',
-            '']:
+            ]:
             return send_from_directory(dir_path, 'deps/' + path)
         if path in ['Bundle.js', 'Bundle.js.map']:
             return send_from_directory(dir_path, 'dist/' + path)

--- a/frontend/deps/Styles.css
+++ b/frontend/deps/Styles.css
@@ -240,6 +240,7 @@ button:focus {
     flex: 1;
     display: flex;
     flex-direction: column;
+    justify-content: center;
     height: 100%;
 }
 .plotter-plots> div> div {
@@ -247,14 +248,21 @@ button:focus {
 }
 .plotter-add-plot {
     flex: 1;
+    max-width: 350px;
 }
 .plot {
     box-sizing: border-box;
     padding: 0 10px 0 10px;
 }
-.plotter-add-plot> img {
-    height: 100%
+
+.plotter-add-plot > svg:hover circle{
+    stroke: lime;
 }
+
+.plotter-add-plot > svg:hover path{
+    fill: lime;
+}
+
 .plot-var {
     display: inline-block;
     width: 50%;

--- a/frontend/deps/add_plot.svg
+++ b/frontend/deps/add_plot.svg
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="256" cy="256" r="224" fill="none" stroke="black" stroke-width="64"/>
-    <path d="M256,256 m-160,-32 l128,0 l0,-128 l64,0 l0,128 l128,0 l0,64 l-128,0 l0,128 l-64,0 l0,-128 l-128,0 z"/>
-</svg> 

--- a/frontend/src/js/components/AddPlotZone.jsx
+++ b/frontend/src/js/components/AddPlotZone.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import {DropTarget} from 'react-dnd';
+import { DropTarget } from 'react-dnd';
 import DragAndDropTypes from '../constants/DragAndDropTypes.js';
 
 class AddPlotZone extends Component {
@@ -70,7 +70,7 @@ const addPlotTarget = {
                 template = item.template;
                 break;
         }
-        component.setState({highlight: undefined}) 
+        component.setState({highlight: false}) 
         props.addPlot(var_name, graphics_method_parent, graphics_method, template, row, col);
     },
     hover(props, monitor, component){
@@ -78,6 +78,7 @@ const addPlotTarget = {
     }
 };
 
+/* istanbul ignore next */
 function collect(connect, monitor) {
     return {
         connectDropTarget: connect.dropTarget(),
@@ -85,4 +86,5 @@ function collect(connect, monitor) {
     };
 }
 
+export { addPlotTarget } // for testing purposes
 export default DropTarget(DragAndDropTypes.PLOT_COMPONENTS, addPlotTarget, collect)(AddPlotZone);

--- a/frontend/src/js/components/AddPlotZone.jsx
+++ b/frontend/src/js/components/AddPlotZone.jsx
@@ -1,0 +1,88 @@
+import React, { Component } from 'react'
+import {DropTarget} from 'react-dnd';
+import DragAndDropTypes from '../constants/DragAndDropTypes.js';
+
+class AddPlotZone extends Component {
+    constructor(props){
+        super(props)
+        this.state = {
+            highlight: false,
+        }
+        this.handleClick = this.handleClick.bind(this)
+    }
+    
+    handleClick(){
+        this.props.addPlot(null, null, null, null, this.props.row, this.props.col)
+    }
+
+    render(){
+        return(
+            this.props.connectDropTarget(
+                <div className='plotter-add-plot'>
+                    <svg viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" onClick={this.handleClick}>
+                        <circle 
+                            cx="256"
+                            cy="256"
+                            r="224"
+                            fill="none"
+                            stroke={this.props.is_over && this.state.highlight ? "lime" : "black"}
+                            strokeWidth="64"
+                        />
+                        <path 
+                            fill={this.props.is_over && this.state.highlight ? "lime" : "black"}
+                            d="M256,256 m-160,-32 l128,0 l0,-128 l64,0 l0,128 l128,0 l0,64 l-128,0 l0,128 l-64,0 l0,-128 l-128,0 z"
+                        />
+                    </svg>
+                </div>
+            )
+        )
+    }
+}
+
+AddPlotZone.propTypes = {
+    connectDropTarget: React.PropTypes.func,
+    is_over: React.PropTypes.bool,
+    addPlot: React.PropTypes.func,
+    row: React.PropTypes.number,
+    col: React.PropTypes.number,
+}
+
+const addPlotTarget = {
+    drop(props, monitor, component) {
+        props.onDrop()
+        const item = monitor.getItem();
+        let var_name = null;
+        let graphics_method_parent = null;
+        let graphics_method = null;
+        let template = null;
+        let row = props.row;
+        let col = props.col;
+
+        switch (monitor.getItemType()) {
+            case DragAndDropTypes.GM:
+                graphics_method_parent = item.gmType;
+                graphics_method = item.gmName;
+                break;
+            case DragAndDropTypes.VAR:
+                var_name = item.variable;
+                break;
+            case DragAndDropTypes.TMPL:
+                template = item.template;
+                break;
+        }
+        component.setState({highlight: undefined}) 
+        props.addPlot(var_name, graphics_method_parent, graphics_method, template, row, col);
+    },
+    hover(props, monitor, component){
+        component.setState({highlight: true})
+    }
+};
+
+function collect(connect, monitor) {
+    return {
+        connectDropTarget: connect.dropTarget(),
+        is_over: monitor.isOver(),
+    };
+}
+
+export default DropTarget(DragAndDropTypes.PLOT_COMPONENTS, addPlotTarget, collect)(AddPlotZone);

--- a/frontend/src/js/components/Plot.jsx
+++ b/frontend/src/js/components/Plot.jsx
@@ -72,7 +72,7 @@ var Plot = React.createClass({
         return this.props.connectDropTarget(
             <div className='plot' id={this.props.plotName} data-plot-index={this.props.plotIndex}>
                 <div>
-                    <h4 style={{color: this.props.isOver && this.state.highlight=="variables"? 'lime' : ''}}>Variables:</h4>
+                    <h4 style={{color: this.props.isOver && this.state.highlight==="variables" ? 'lime' : ''}}>Variables:</h4>
                     <div className='plot-var first-var'>{(this.props.plot.variables.length > 0 && this.props.plot.variables[0]
                             ? this.props.plot.variables[0]
                             : '')}

--- a/frontend/src/js/components/Plotter.jsx
+++ b/frontend/src/js/components/Plotter.jsx
@@ -1,94 +1,6 @@
-import React, { Component } from 'react'
+import React from 'react'
 import Plot from './Plot.jsx'
-import {DropTarget} from 'react-dnd';
-import DragAndDropTypes from '../constants/DragAndDropTypes.js';
-
-
-class AddPlot extends Component {
-    constructor(props){
-        super(props)
-        this.state = {
-            highlight: false,
-        }
-        this.handleClick = this.handleClick.bind(this)
-    }
-    
-    handleClick(){
-        this.props.addPlot(null, null, null, null, this.props.row, this.props.col)
-    }
-
-    render(){
-        return(
-            this.props.connectDropTarget(
-                <div className='plotter-add-plot'>
-                    <svg viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" onClick={this.handleClick}>
-                        <circle 
-                            cx="256"
-                            cy="256"
-                            r="224"
-                            fill="none"
-                            stroke={this.props.is_over && this.state.highlight ? "lime" : "black"}
-                            strokeWidth="64"
-                        />
-                        <path 
-                            fill={this.props.is_over && this.state.highlight ? "lime" : "black"}
-                            d="M256,256 m-160,-32 l128,0 l0,-128 l64,0 l0,128 l128,0 l0,64 l-128,0 l0,128 l-64,0 l0,-128 l-128,0 z"
-                        />
-                    </svg>
-                </div>
-            )
-        )
-    }
-}
-
-AddPlot.propTypes = {
-    connectDropTarget: React.PropTypes.func,
-    is_over: React.PropTypes.bool,
-    addPlot: React.PropTypes.func,
-    row: React.PropTypes.number,
-    col: React.PropTypes.number,
-}
-
-const addPlotTarget = {
-    drop(props, monitor, component) {
-        props.onDrop()
-        const item = monitor.getItem();
-        let var_name = null;
-        let graphics_method_parent = null;
-        let graphics_method = null;
-        let template = null;
-        let row = props.row;
-        let col = props.col;
-
-        switch (monitor.getItemType()) {
-            case DragAndDropTypes.GM:
-                graphics_method_parent = item.gmType;
-                graphics_method = item.gmName;
-                break;
-            case DragAndDropTypes.VAR:
-                var_name = item.variable;
-                break;
-            case DragAndDropTypes.TMPL:
-                template = item.template;
-                break;
-        }
-        component.setState({highlight: undefined}) 
-        props.addPlot(var_name, graphics_method_parent, graphics_method, template, row, col);
-    },
-    hover(props, monitor, component){
-        component.setState({highlight: true})
-    }
-};
-
-const DropPlot = DropTarget(DragAndDropTypes.PLOT_COMPONENTS, addPlotTarget, collect)(AddPlot);
-
-function collect(connect, monitor) {
-    return {
-        connectDropTarget: connect.dropTarget(),
-        is_over: monitor.isOver(),
-    };
-}
-
+import AddPlotZone from './AddPlotZone.jsx'
 /* global $*/
 
 var Plotter = React.createClass({
@@ -131,7 +43,7 @@ var Plotter = React.createClass({
                         }
                         return plotters;
                     })()}
-                    <DropPlot 
+                    <AddPlotZone 
                         onHover={this.props.onHover}
                         onDrop={this.props.onDrop}
                         addPlot={this.props.addPlot}

--- a/frontend/src/js/components/Plotter.jsx
+++ b/frontend/src/js/components/Plotter.jsx
@@ -1,15 +1,45 @@
-import React from 'react'
+import React, { Component } from 'react'
 import Plot from './Plot.jsx'
 import {DropTarget} from 'react-dnd';
 import DragAndDropTypes from '../constants/DragAndDropTypes.js';
 
 
-function AddPlot(props) {
-    return props.connectDropTarget(
-        <div className='plotter-add-plot'>
-            <img src='deps/add_plot.svg' alt='Add Plot'></img>
-        </div>
-    );
+class AddPlot extends Component {
+    constructor(props){
+        super(props)
+        this.state = {
+            highlight: false,
+        }
+    }
+    
+    render(){
+        return(
+            this.props.connectDropTarget(
+                <div className='plotter-add-plot'>
+                    <svg viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" onClick={this.props.handleClick}>
+                        <circle 
+                            cx="256"
+                            cy="256"
+                            r="224"
+                            fill="none"
+                            stroke={this.props.is_over && this.state.highlight ? "lime" : "black"}
+                            strokeWidth="64"
+                        />
+                        <path 
+                            fill={this.props.is_over && this.state.highlight ? "lime" : "black"}
+                            d="M256,256 m-160,-32 l128,0 l0,-128 l64,0 l0,128 l128,0 l0,64 l-128,0 l0,128 l-64,0 l0,-128 l-128,0 z"
+                        />
+                    </svg>
+                </div>
+            )
+        )
+    }
+}
+
+AddPlot.propTypes = {
+    connectDropTarget: React.PropTypes.func,
+    is_over: React.PropTypes.bool,
+    handleClick: React.PropTypes.func,
 }
 
 const addPlotTarget = {
@@ -35,7 +65,11 @@ const addPlotTarget = {
                 template = item.template;
                 break;
         }
+        component.setState({highlight: undefined}) 
         props.addPlot(var_name, graphics_method_parent, graphics_method, template, row, col);
+    },
+    hover(props, monitor, component){
+        component.setState({highlight: true})
     }
 };
 
@@ -44,7 +78,7 @@ const DropPlot = DropTarget(DragAndDropTypes.PLOT_COMPONENTS, addPlotTarget, col
 function collect(connect, monitor) {
     return {
         connectDropTarget: connect.dropTarget(),
-        isOver: monitor.isOver(),
+        is_over: monitor.isOver(),
     };
 }
 

--- a/frontend/src/js/components/Plotter.jsx
+++ b/frontend/src/js/components/Plotter.jsx
@@ -10,13 +10,18 @@ class AddPlot extends Component {
         this.state = {
             highlight: false,
         }
+        this.handleClick = this.handleClick.bind(this)
     }
     
+    handleClick(){
+        this.props.addPlot(null, null, null, null, this.props.row, this.props.col)
+    }
+
     render(){
         return(
             this.props.connectDropTarget(
                 <div className='plotter-add-plot'>
-                    <svg viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" onClick={this.props.handleClick}>
+                    <svg viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" onClick={this.handleClick}>
                         <circle 
                             cx="256"
                             cy="256"
@@ -39,7 +44,9 @@ class AddPlot extends Component {
 AddPlot.propTypes = {
     connectDropTarget: React.PropTypes.func,
     is_over: React.PropTypes.bool,
-    handleClick: React.PropTypes.func,
+    addPlot: React.PropTypes.func,
+    row: React.PropTypes.number,
+    col: React.PropTypes.number,
 }
 
 const addPlotTarget = {
@@ -124,7 +131,13 @@ var Plotter = React.createClass({
                         }
                         return plotters;
                     })()}
-                    <DropPlot onHover={this.props.onHover} onDrop={this.props.onDrop} addPlot={this.props.addPlot} row={this.props.row} col={this.props.col}/>
+                    <DropPlot 
+                        onHover={this.props.onHover}
+                        onDrop={this.props.onDrop}
+                        addPlot={this.props.addPlot}
+                        row={this.props.row}
+                        col={this.props.col}
+                    />
                 </div>
             </div>
         )

--- a/frontend/test/mocha/components/AddPlotZoneTest.jsx
+++ b/frontend/test/mocha/components/AddPlotZoneTest.jsx
@@ -1,0 +1,120 @@
+/* globals it, describe, before, beforeEach, */
+var chai = require('chai');
+var expect = chai.expect;
+var React = require('react') // needed to use jsx
+import { shallow } from 'enzyme'
+import sinon from 'sinon'
+import AddPlotZone, { addPlotTarget } from '../../../../frontend/src/js/components/AddPlotZone.jsx'
+import DragAndDropTypes from '../../../src/js/constants/DragAndDropTypes';
+
+
+var UnwrappedAddPlotZone = AddPlotZone.DecoratedComponent
+
+describe('PlotToolsTest.jsx', function() {
+    it('renders without exploding', () => {
+        const dummyFunction = el => el // return whatever we are given
+        const add_plot_zone = shallow(<UnwrappedAddPlotZone connectDropTarget={dummyFunction}/>)
+        expect(add_plot_zone).to.have.lengthOf(1);
+    });
+
+    it('Drop works with GM', () => {
+        const props = {
+            onDrop: sinon.spy(),
+            addPlot: sinon.spy(),
+            row: 0,
+            col: 0,
+        }
+        let monitor = {
+            getItemType: sinon.stub().returns(DragAndDropTypes.GM),
+            getItem: ()=>{return {gmType: "gmtype", gmName:"gmname"}},
+        }
+        const component = {
+            setState: sinon.spy(),
+        }
+        addPlotTarget.drop(props, monitor, component)
+        expect(props.onDrop.calledOnce).to.be.true
+        expect(props.addPlot.calledOnce).to.be.true
+        expect(props.addPlot.getCall(0).args[0]).to.equal(null) // variable
+        expect(props.addPlot.getCall(0).args[1]).to.equal("gmtype") // graphics_method_parent
+        expect(props.addPlot.getCall(0).args[2]).to.equal("gmname") // graphics_method
+        expect(props.addPlot.getCall(0).args[3]).to.equal(null) // template
+        expect(props.addPlot.getCall(0).args[4]).to.equal(0) // row
+        expect(props.addPlot.getCall(0).args[5]).to.equal(0) // col
+        expect(component.setState.calledOnce).to.be.true
+    });
+
+    it('Drop works with VAR', () => {
+        const props = {
+            onDrop: sinon.spy(),
+            addPlot: sinon.spy(),
+            row: 1,
+            col: 1,
+        }
+        let monitor = {
+            getItemType: sinon.stub().returns(DragAndDropTypes.VAR),
+            getItem: ()=>{return {variable: "varname"}},
+        }
+        const component = {
+            setState: sinon.spy(),
+        }
+        addPlotTarget.drop(props, monitor, component)
+        expect(props.onDrop.calledOnce).to.be.true
+        expect(props.addPlot.calledOnce).to.be.true
+        expect(props.addPlot.getCall(0).args[0]).to.equal("varname") // variable
+        expect(props.addPlot.getCall(0).args[1]).to.equal(null) // graphics_method_parent
+        expect(props.addPlot.getCall(0).args[2]).to.equal(null) // graphics_method
+        expect(props.addPlot.getCall(0).args[3]).to.equal(null) // template
+        expect(props.addPlot.getCall(0).args[4]).to.equal(1) // row
+        expect(props.addPlot.getCall(0).args[5]).to.equal(1) // col
+        expect(component.setState.calledOnce).to.be.true
+    });
+
+    it('Drop works with TMPL', () => {
+        const props = {
+            onDrop: sinon.spy(),
+            addPlot: sinon.spy(),
+            row: 2,
+            col: 2,
+        }
+        let monitor = {
+            getItemType: sinon.stub().returns(DragAndDropTypes.TMPL),
+            getItem: ()=>{return {template: "template"}},
+        }
+        const component = {
+            setState: sinon.spy(),
+        }
+        addPlotTarget.drop(props, monitor, component)
+        expect(props.onDrop.calledOnce).to.be.true
+        expect(props.addPlot.calledOnce).to.be.true
+        expect(props.addPlot.getCall(0).args[0]).to.equal(null) // variable
+        expect(props.addPlot.getCall(0).args[1]).to.equal(null) // graphics_method_parent
+        expect(props.addPlot.getCall(0).args[2]).to.equal(null) // graphics_method
+        expect(props.addPlot.getCall(0).args[3]).to.equal("template") // template
+        expect(props.addPlot.getCall(0).args[4]).to.equal(2) // row
+        expect(props.addPlot.getCall(0).args[5]).to.equal(2) // col
+        expect(component.setState.calledOnce).to.be.true
+    });
+
+    it('Hover works', () => {
+        const component = {
+            setState: sinon.spy()
+        }
+        addPlotTarget.hover(null, null, component)
+        expect(component.setState.calledOnce).to.be.true
+        expect(component.setState.getCall(0).args)
+    });
+
+    it('Click calls addPlot', () => {
+        const dummyFunction = el => el
+        const addPlot = sinon.spy()
+        const add_plot_zone = shallow(<UnwrappedAddPlotZone connectDropTarget={dummyFunction} addPlot={addPlot} row={0} col={0}/>)
+        add_plot_zone.find("svg").simulate("click")
+        expect(addPlot.calledOnce).to.be.true
+        expect(addPlot.getCall(0).args[0]).to.equal(null)
+        expect(addPlot.getCall(0).args[1]).to.equal(null)
+        expect(addPlot.getCall(0).args[2]).to.equal(null)
+        expect(addPlot.getCall(0).args[3]).to.equal(null)
+        expect(addPlot.getCall(0).args[4]).to.equal(0)
+        expect(addPlot.getCall(0).args[5]).to.equal(0)
+    });
+});


### PR DESCRIPTION
Makes the 'giant plus' highlight when hovered or dragged over. Also makes it clickable to add a plot. 
Removes the svg deps file and inlines it instead so that css can be used on it. (Wrapping it in an img tag prevents this)

Fixes #229  
Fixes #244 