### PR TITLE
Fixes save problem introduced during React v16 refactor

### DIFF
--- a/frontend/src/js/components/modals/GraphicsMethodEditor.jsx
+++ b/frontend/src/js/components/modals/GraphicsMethodEditor.jsx
@@ -41,7 +41,7 @@ class GraphicsMethodEditor extends Component {
                         <Button onClick={this.props.onHide}>Cancel</Button>
                         <Button
                             onClick={() => {
-                                this.props.updateGraphicsMethod(self.state.workingGraphicsMethod); self.props.onHide() 
+                                this.props.updateGraphicsMethod(this.state.workingGraphicsMethod); this.props.onHide() 
                             }}>Save
                         </Button>
                     </ButtonToolbar>


### PR DESCRIPTION
When refactoring I removed `const self = this` but forgot to change other references to `self` over to `this`