### PR TITLE
Fix stdin bug

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14420,9 +14420,9 @@
       }
     },
     "vcs-widgets": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/vcs-widgets/-/vcs-widgets-0.1.3.tgz",
-      "integrity": "sha512-KGjvlC6zJeOCSdnDmmeBGUUNlYqWzBAd52Sj/x5egZiCacP00a8oYR4e8Cy0++UuDC+LYFAsBcivQkWLOT63cw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/vcs-widgets/-/vcs-widgets-0.1.4.tgz",
+      "integrity": "sha512-9J+AJV89gma9tdyQDNZD/a6AW6H4wEFB3c/OQaWw1JjR0koZmjqLAEbiGCUPit3zueHyf5Kv00L06MrkpXe+XQ==",
       "requires": {
         "jquery": "3.3.1",
         "npm": "5.8.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "react-toastify": "^3.3.1",
     "redux": "=3.7.2",
     "redux-undo": "^0.6.1",
-    "vcs-widgets": "^0.1.3"
+    "vcs-widgets": "^0.1.4"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",

--- a/scripts/vcdat
+++ b/scripts/vcdat
@@ -82,7 +82,7 @@ while True:
 
 # Now we'll wait till the user terminates the process.
 try:
-    for line in sys.stdin:
+    while True:
         pass
 except KeyboardInterrupt:
     print ""

--- a/scripts/vcdat
+++ b/scripts/vcdat
@@ -10,7 +10,6 @@ import argparse
 def isBound(port):
     import socket
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     try:
         s.bind(("localhost", int(port)))
     except socket.error as e:


### PR DESCRIPTION
Fixes issue where using running vcdat in the background or with jenkins would fail due to stdin receiving EOF. Also fixes issue where port detection would fail if another instance of vcdat was using the port, causing vcdat to fail to start up properly. Lastly, updates vcs-widgets version to the latest. 