### PR TITLE
Makes log file have a consistent name

### DIFF
--- a/scripts/vcdat
+++ b/scripts/vcdat
@@ -36,7 +36,7 @@ VCSJS_PORT = getPort("VCSJS_PORT", "8000")
 VCDAT_PORT = getPort("VCDAT_PORT", "5000")
 
 os.environ["UVCDAT_ANONYMOUS_LOG"] = "no"
-logfile = tempfile.NamedTemporaryFile()
+logfile = open(os.path.join(tempfile.gettempdir(), "vcdat.log"), 'w+')
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--print-log", help="Output to screen instead of log file", action='store_true') # Because i cant do --print for whatever reason.


### PR DESCRIPTION
Fixes #284

The only aspect that was not fixed was the file location. vCDAT will use whatever temporary path python gives it and will create a vcdat.log file inside that directory. 

The user is able to override the default temp directory by setting the `TMPDIR` environment variable. 

