### PR TITLE
Move gm methods

### DIFF
--- a/backend/vcdat/GraphicsMethods.py
+++ b/backend/vcdat/GraphicsMethods.py
@@ -3,28 +3,9 @@ import json
 import numpy
 
 _ = vcs.init()
-_methods = {}
 _2d_methods = ('scatter', 'vector', 'xvsy', 'stream', 'glyph', '3d_vector', '3d_dual_scalar')
 _primitives = ('line', 'marker', 'fillarea', 'text')
 
-
-def get_gm():
-    for t in vcs.graphicsmethodlist():
-        _methods[t] = {}
-        for m in vcs.elements[t].keys():
-            gm = vcs.elements[t][m]
-            _methods[t][m] = vcs.dumpToDict(gm)[0]
-            if hasattr(gm, "levels"):
-                arr = numpy.array(gm.levels)
-                if numpy.allclose(arr, 1e20) and arr.shape[-1] == 2:
-                    _methods[t][m]["levels"] = [1e20, 1e20]
-    return _methods
-
-def get_default_gms():
-    _defaults = {}
-    for t in vcs.graphicsmethodlist():
-        _defaults[t] = vcs.elements[t].keys()
-    return _defaults
 
 def detect_nvars(g_type, g_method, g_obj):
     """Try to return the number of variables required for the plot method.

--- a/backend/vcdat/app.py
+++ b/backend/vcdat/app.py
@@ -5,7 +5,6 @@ import vcs
 import cdms2
 import json
 from flask import Flask, send_from_directory, request, send_file, Response, jsonify
-from GraphicsMethods import get_gm, get_default_gms
 from Templates import templ_from_json
 from Files import getFilesObject
 from Colormaps import get_cmaps
@@ -118,13 +117,6 @@ def plot_template():
     del vcs.elements["boxfill"][g.name] 
     del vcs.elements["template"][t.name]
     return resp
-
-  
-@app.route("/getGraphicsMethods")
-@jsonresp
-def get_graphics_methods():
-    graphics_methods = get_gm()
-    return json.dumps(graphics_methods)
 
   
 @app.route("/getDefaultMethods")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,10 @@
   "description": "Front-end GUI for CDAT",
   "main": "src/js/app.js",
   "private": true,
+  "prettier": {
+    "printWidth": 150,
+    "tabWidth": 4
+  },
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "bootstrap-slider": "git://github.com/matthewma7/bootstrap-slider",

--- a/frontend/src/js/Store.js
+++ b/frontend/src/js/Store.js
@@ -6,6 +6,7 @@ import GraphicsMethodModel from './models/GraphicsMethods.js';
 import TemplateModel from './models/Templates.js';
 import VariableModel from './models/Variables.js';
 import SpreadsheetModel from './models/Spreadsheet.js';
+import UIModel from './models/UI.js';
 
 /* global $ */
 
@@ -16,7 +17,8 @@ const reducers = combineReducers({
     graphics_methods: GraphicsMethodModel.reduce,
     templates: TemplateModel.reduce,
     sheets_model: SpreadsheetModel.reduce,
-    colormaps: ColormapModel.reduce
+    colormaps: ColormapModel.reduce,
+    ui: UIModel.reduce,
 });
 
 const undoableReducer = undoable(reducers,{
@@ -31,12 +33,12 @@ var store = null;
 const configureStore = (initialState = {}) => {
     let state = Promise.resolve(initialState);
     if (Object.keys(initialState).length === 0) {
-        const models = [CachedFileModel, VariableModel, GraphicsMethodModel, TemplateModel, SpreadsheetModel, ColormapModel]
+        const models = [CachedFileModel, VariableModel, GraphicsMethodModel, TemplateModel, SpreadsheetModel, ColormapModel, UIModel]
         const initialStates = models.map((m) => {
             return m.getInitialState();
         });
         state = Promise.all(initialStates).then((values) => {
-            const cached_files = values[0], variables = values[1], graphics_methods = values[2], templates = values[3], sheets_model = values[4], colormaps = values[5];
+            const cached_files = values[0], variables = values[1], graphics_methods = values[2], templates = values[3], sheets_model = values[4], colormaps = values[5], ui = values[6];
             return {
                 present: {
                     cached_files,
@@ -44,7 +46,8 @@ const configureStore = (initialState = {}) => {
                     graphics_methods,
                     templates,
                     sheets_model,
-                    colormaps
+                    colormaps,
+                    ui,
                 },
             };
         });

--- a/frontend/src/js/components/GMList.jsx
+++ b/frontend/src/js/components/GMList.jsx
@@ -32,15 +32,13 @@ class GMList extends Component {
     constructor(props){
         super(props)
         this.state = {
-            activeGM: false,
-            activeGMParent: false,
             show_edit_modal: false,
             show_create_modal: false,
         }
         this.clickedAdd = this.clickedAdd.bind(this)
         this.clickedEdit = this.clickedEdit.bind(this)
         this.clickedRemove= this.clickedRemove.bind(this)
-        this.closeModal = this.closeEditModal.bind(this)
+        this.closeEditModal = this.closeEditModal.bind(this)
         this.selectedChild = this.selectedChild.bind(this)
     }
 
@@ -49,7 +47,7 @@ class GMList extends Component {
     }
 
     clickedEdit() {
-        const gm = this.props.graphics_methods[this.state.activeGMParent][this.state.activeGM] 
+        const gm = this.props.graphics_methods[this.props.selected_graphics_type][this.props.selected_graphics_method] 
         if (SUPPORTED_GM_EDITORS && !SUPPORTED_GM_EDITORS.includes(gm.g_name)) {
             toast.warn("This graphics method does not have an editor yet.", { position: toast.POSITION.BOTTOM_CENTER })
         }
@@ -104,7 +102,7 @@ class GMList extends Component {
                     this.props.graphics_methods[this.props.selected_graphics_type][this.props.selected_graphics_method]) ?
                         <GraphicsMethodEditor
                             colormaps={this.props.colormaps}
-                            graphicsMethod={this.props.graphics_methods[this.state.activeGMParent][this.state.activeGM]}
+                            graphicsMethod={this.props.graphics_methods[this.props.selected_graphics_type][this.props.selected_graphics_method]}
                             updateGraphicsMethod={this.props.updateGraphicsMethod}
                             show={this.state.show_edit_modal}
                             onHide={this.closeEditModal}

--- a/frontend/src/js/components/GMList.jsx
+++ b/frontend/src/js/components/GMList.jsx
@@ -49,8 +49,13 @@ class GMList extends Component {
     }
 
     clickedEdit() {
+        if(!this.props.selected_graphics_type || !this.props.selected_graphics_method) {
+            toast.info("A Graphics Method must be selected to edit", { position: toast.POSITION.BOTTOM_CENTER })
+            return
+        }
+
         const gm = this.props.graphics_methods[this.props.selected_graphics_type][this.props.selected_graphics_method]
-        if (SUPPORTED_GM_EDITORS && !SUPPORTED_GM_EDITORS.includes(gm.g_name)) {
+        if(SUPPORTED_GM_EDITORS && !SUPPORTED_GM_EDITORS.includes(gm.g_name)) {
             toast.warn("This graphics method does not have an editor yet.", { position: toast.POSITION.BOTTOM_CENTER })
         }
         else {

--- a/frontend/src/js/components/GMList.jsx
+++ b/frontend/src/js/components/GMList.jsx
@@ -38,7 +38,8 @@ class GMList extends Component {
         }
         this.clickedAdd = this.clickedAdd.bind(this)
         this.clickedEdit = this.clickedEdit.bind(this)
-        this.clickedRemove= this.clickedRemove.bind(this)
+        this.confirmRemove = this.confirmRemove.bind(this)
+        this.removeGM = this.removeGM.bind(this)
         this.closeEditModal = this.closeEditModal.bind(this)
         this.selectedChild = this.selectedChild.bind(this)
     }
@@ -138,7 +139,7 @@ class GMList extends Component {
                     addText="Create a new Graphics Method"
                     editAction={this.clickedEdit}
                     editText="Edit a selected graphics method"
-                    removeAction={this.clickedRemove}
+                    removeAction={this.confirmRemove}
                     removeText="Removing a graphics method is not supported yet"
                 />
                 {(this.props.selected_graphics_type &&

--- a/frontend/src/js/components/GMList.jsx
+++ b/frontend/src/js/components/GMList.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import AddEditRemoveNav from './AddEditRemoveNav/AddEditRemoveNav.jsx'
+import GraphicsMethodCreator from './modals/GraphicsMethodCreator.jsx'
 import GraphicsMethodEditor from './modals/GraphicsMethodEditor.jsx'
 import Tree from './Tree.jsx'
 import DragAndDropTypes from '../constants/DragAndDropTypes.js'
@@ -31,11 +32,18 @@ class GMList extends Component {
         this.state = {
             activeGM: false,
             activeGMParent: false,
-            showModal: false
+            show_edit_modal: false,
+            show_create_modal: false,
         }
+        this.clickedAdd = this.clickedAdd.bind(this)
         this.clickedEdit = this.clickedEdit.bind(this)
-        this.closedModal = this.closedModal.bind(this)
+        this.clickedRemove= this.clickedRemove.bind(this)
+        this.closeModal = this.closeEditModal.bind(this)
         this.selectedChild = this.selectedChild.bind(this)
+    }
+
+    clickedAdd() {
+        this.setState({show_create_modal: true})
     }
 
     clickedEdit() {
@@ -44,12 +52,16 @@ class GMList extends Component {
             toast.warn("This graphics method does not have an editor yet.", { position: toast.POSITION.BOTTOM_CENTER })
         }
         else {
-            this.setState({showModal: true})
+            this.setState({show_edit_modal: true})
         }
     }
 
-    closedModal() {
-        this.setState({showModal: false})
+    clickedRemove() {
+
+    }
+
+    closeEditModal() {
+        this.setState({show_edit_modal: false})
     }
 
     selectedChild(path) {
@@ -82,9 +94,11 @@ class GMList extends Component {
             <div className='left-side-list scroll-area-list-parent gm-list-container'>
                 <AddEditRemoveNav 
                     title='Graphics Methods'
+                    addAction={this.clickedAdd}
+                    addText="Create a new Graphics Method"
                     editAction={this.clickedEdit}
-                    addText="Creating a graphics method is not supported yet"
                     editText="Edit a selected graphics method"
+                    removeAction={this.clickedRemove}
                     removeText="Removing a graphics method is not supported yet"
                 />
                 {
@@ -93,8 +107,8 @@ class GMList extends Component {
                             colormaps={this.props.colormaps}
                             graphicsMethod={this.props.graphicsMethods[this.state.activeGMParent][this.state.activeGM]}
                             updateGraphicsMethod={this.props.updateGraphicsMethod}
-                            show={this.state.showModal}
-                            onHide={this.closedModal}
+                            show={this.state.show_edit_modal}
+                            onHide={this.closeEditModal}
                         />
                     :   
                         ""

--- a/frontend/src/js/components/TemplateList.jsx
+++ b/frontend/src/js/components/TemplateList.jsx
@@ -62,7 +62,15 @@ class TemplateList extends Component {
         else{
             this.setState({showTemplateEditor: true, template_data: "loading"})
             return vcs.gettemplate(this.props.selected_template).then((data)=>{ // return promise for testing purposes
-                this.setState({template_data: data})
+                if(data) { 
+                    this.setState({template_data: data})
+                }
+                else { // data will be null if the selected template doesnt exist
+                    // We can probably do more error handling here. Refresh the names, and deselect the selected template
+                    toast.error(`${this.props.selected_template} doesn't exist on the server. Try refreshing the browser window.`,
+                        { position: toast.POSITION.BOTTOM_CENTER }
+                    )
+                }
             },
             (error) => {
                 console.warn(error)

--- a/frontend/src/js/components/modals/GraphicsMethodCreator.jsx
+++ b/frontend/src/js/components/modals/GraphicsMethodCreator.jsx
@@ -1,0 +1,170 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import Actions from '../../constants/Actions.js'
+import { Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock} from 'react-bootstrap'
+import { toast } from 'react-toastify'
+
+class GraphicsMethodCreator extends Component {
+    constructor(props){
+        super(props)
+        let default_gm_type = ""
+        let default_gm_method = ""
+        const gm_types = Object.keys(props.graphics_methods)
+
+        if(gm_types.length > 0) {
+            default_gm_type = props.graphics_methods[0] // just grab the first one each time since there isnt really a default
+        }
+
+        if(default_gm_type){ // can't select a graphics method if the types weren't defined
+            const gm_methods = Object.keys(props.graphics_methods[default_gm_type])
+            if(gm_methods.indexOf("default") >= 0) {
+                default_gm_method = "default"
+            }
+            else if(gm_methods.length > 0) {
+                default_gm_method = gm_methods[0]
+            }
+        }
+        
+        this.state = {
+            new_gm_name: "",
+            validation_state: null,
+            selected_gm_type: default_gm_type,
+            selected_gm_method: default_gm_method,
+        }
+
+        this.createGraphicsMethod = this.createGraphicsMethod.bind(this)
+        this.handleChange = this.handleChange.bind(this)
+    }
+
+    handleChange(event) {
+        const name = event.target.value
+        const validation_state = this.getValidationState(name, this.state.selected_gm_type)
+        this.setState({new_template_name: name, validation_state: validation_state})
+    }
+
+    getValidationState(name, gm_type){
+        if(name.length === 0 || gm_type === "" ){
+            return null
+        }
+        else if(Object.keys(this.props.graphics_methods[gm_type]).indexOf(name) > -1) {
+            return "error"
+        }
+        return "success"
+    }
+
+    createTemplate() {
+        try {
+            return vcs.creategraphicsmethod(this.state.selected_gm_type, this.state.new_gm_name, this.state.selected_gm_method).then(
+                (/* success */) => {
+                    this.props.createGraphicsMethod(this.state.selected_gm_type, this.state.new_gm_name)
+                    toast.success("Graphics Method created successfully!", {position: toast.POSITION.BOTTOM_CENTER})
+                    this.props.close()
+                },
+                /* istanbul ignore next */
+                (error) => {
+                    console.warn("Error while creating Graphics Method: ", error)
+                    try{
+                        toast.error(error.data.exception, {position: toast.POSITION.BOTTOM_CENTER})
+                    }
+                    catch(e){
+                        toast.error("Failed to create template", {position: toast.POSITION.BOTTOM_CENTER})
+                    }
+                }
+            )
+        }
+        catch(e) {
+            /* istanbul ignore next */
+            console.warn(e)
+            /* istanbul ignore next */
+            toast.error("An error occurred while creating the template. Try restarting vCDAT.")
+        }
+    }
+
+    render() {
+        return (
+            <Modal show={this.props.show} onHide={this.props.close}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Create a Graphics Method</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>    
+                    <FormGroup
+                        controlId="formBasicText"
+                        validationState={this.state.validation_state}
+                    >
+                        <ControlLabel>New Graphics Method Name</ControlLabel>
+                        <FormControl
+                            type="text"
+                            value={this.state.new_gm_name}
+                            onChange={this.handleChange}
+                        />
+                        <FormControl.Feedback />
+                        <HelpBlock>
+                            { this.state.validation_state === "error" ? "A graphics method with that name already exists." : null }
+                        </HelpBlock>
+                    </FormGroup>
+                    <FormGroup controlId="formControlsSelectType">
+                        <ControlLabel>Base Graphics Type</ControlLabel>
+                        <FormControl
+                            componentClass="select"
+                            value={this.state.selected_gm_type}
+                            onChange={(e)=>this.setState({selected_gm_type: e.target.value})}
+                        >
+                        {
+                            Object.keys(this.props.graphics_methods).map((name) => {
+                                return <option key={name} value={name}>{name}</option>
+                            })
+                        }
+                        </FormControl>
+                    </FormGroup>
+                    <FormGroup controlId="formControlsSelectMethod">
+                        <ControlLabel>Base Graphics Method</ControlLabel>
+                        <FormControl
+                            componentClass="select"
+                            value={this.state.selected_gm_method}
+                            onChange={(e)=>this.setState({selected_gm_method: e.target.value})}
+                        >
+                        { this.props.graphics_methods[this.state.selected_gm_type] ?
+                            Object.keys(this.props.graphics_methods[this.state.selected_gm_type]).map((name) => {
+                                return <option key={name} value={name}>{name}</option>
+                            })
+                            :
+                                <option value=""></option>
+                        }
+                        </FormControl>
+                    </FormGroup>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button
+                        bsStyle="primary"
+                        disabled={this.state.validation_state !== "success" } 
+                        onClick={this.createTemplate}
+                    >Create
+                    </Button>
+                    <Button onClick={this.props.close} bsStyle="default">Cancel</Button>    
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+GraphicsMethodCreator.propTypes = {
+    show: PropTypes.bool,
+    close: PropTypes.func,
+    graphics_methods: PropTypes.objectOf(
+        PropTypes.objectOf(
+            PropTypes.object
+        )
+    ),
+    createGraphicsMethod: PropTypes.func,
+}
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        createGraphicsMethod: (type, name) => {
+            dispatch(Actions.createGraphicsMethod(type, name))
+        }
+    }
+}
+export { GraphicsMethodCreator as PureGraphicsMethodCreator}
+export default connect(null, mapDispatchToProps)(GraphicsMethodCreator);

--- a/frontend/src/js/components/modals/GraphicsMethodCreator.jsx
+++ b/frontend/src/js/components/modals/GraphicsMethodCreator.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import Actions from '../../constants/Actions.js'
-import { Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock} from 'react-bootstrap'
+import { Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock, Row, Col} from 'react-bootstrap'
 import { toast } from 'react-toastify'
 
 class GraphicsMethodCreator extends Component {
@@ -13,7 +13,7 @@ class GraphicsMethodCreator extends Component {
         const gm_types = Object.keys(props.graphics_methods)
 
         if(gm_types.length > 0) {
-            default_gm_type = props.graphics_methods[0] // just grab the first one each time since there isnt really a default
+            default_gm_type = Object.keys(props.graphics_methods)[0] // just grab the first one each time since there isnt really a default
         }
 
         if(default_gm_type){ // can't select a graphics method if the types weren't defined
@@ -40,7 +40,7 @@ class GraphicsMethodCreator extends Component {
     handleChange(event) {
         const name = event.target.value
         const validation_state = this.getValidationState(name, this.state.selected_gm_type)
-        this.setState({new_template_name: name, validation_state: validation_state})
+        this.setState({new_gm_name: name, validation_state: validation_state})
     }
 
     getValidationState(name, gm_type){
@@ -53,11 +53,11 @@ class GraphicsMethodCreator extends Component {
         return "success"
     }
 
-    createTemplate() {
+    createGraphicsMethod() {
         try {
             return vcs.creategraphicsmethod(this.state.selected_gm_type, this.state.new_gm_name, this.state.selected_gm_method).then(
                 (/* success */) => {
-                    this.props.createGraphicsMethod(this.state.selected_gm_type, this.state.new_gm_name)
+                    this.props.createGraphicsMethod(this.state.new_gm_name, this.state.selected_gm_type, this.state.selected_gm_method)
                     toast.success("Graphics Method created successfully!", {position: toast.POSITION.BOTTOM_CENTER})
                     this.props.close()
                 },
@@ -68,7 +68,7 @@ class GraphicsMethodCreator extends Component {
                         toast.error(error.data.exception, {position: toast.POSITION.BOTTOM_CENTER})
                     }
                     catch(e){
-                        toast.error("Failed to create template", {position: toast.POSITION.BOTTOM_CENTER})
+                        toast.error("Failed to create Graphics Method", {position: toast.POSITION.BOTTOM_CENTER})
                     }
                 }
             )
@@ -77,7 +77,7 @@ class GraphicsMethodCreator extends Component {
             /* istanbul ignore next */
             console.warn(e)
             /* istanbul ignore next */
-            toast.error("An error occurred while creating the template. Try restarting vCDAT.")
+            toast.error("An error occurred while creating the Graphics Method. Try restarting vCDAT.")
         }
     }
 
@@ -87,7 +87,49 @@ class GraphicsMethodCreator extends Component {
                 <Modal.Header closeButton>
                     <Modal.Title>Create a Graphics Method</Modal.Title>
                 </Modal.Header>
-                <Modal.Body>    
+                <Modal.Body>
+                    <Row>
+                        <Col sm={6}>
+                            <FormGroup controlId="formControlsSelectType">
+                                <ControlLabel>Base Graphics Type</ControlLabel>
+                                <FormControl
+                                    componentClass="select"
+                                    value={this.state.selected_gm_type}
+                                    onChange={(e)=>this.setState({selected_gm_type: e.target.value})}
+                                >
+                                {
+                                    Object.keys(this.props.graphics_methods).map((name) => {
+                                        return <option key={name} value={name}>{name}</option>
+                                    })
+                                }
+                                </FormControl>
+                                <HelpBlock style={{fontSize: "12px"}}>
+                                    Select a type for your new graphics method
+                                </HelpBlock>
+                            </FormGroup>
+                        </Col>
+                        <Col sm={6}>
+                            <FormGroup controlId="formControlsSelectMethod">
+                                <ControlLabel>Base Graphics Method</ControlLabel>
+                                <FormControl
+                                    componentClass="select"
+                                    value={this.state.selected_gm_method}
+                                    onChange={(e)=>this.setState({selected_gm_method: e.target.value})}
+                                >
+                                { this.props.graphics_methods[this.state.selected_gm_type] ?
+                                    Object.keys(this.props.graphics_methods[this.state.selected_gm_type]).map((name) => {
+                                        return <option key={name} value={name}>{name}</option>
+                                    })
+                                    :
+                                        <option value=""></option>
+                                }
+                                </FormControl>
+                                <HelpBlock style={{fontSize: "12px"}}>
+                                    Select an existing graphics method to copy and use as a base.
+                                </HelpBlock>
+                            </FormGroup>
+                        </Col>
+                    </Row>
                     <FormGroup
                         controlId="formBasicText"
                         validationState={this.state.validation_state}
@@ -103,42 +145,12 @@ class GraphicsMethodCreator extends Component {
                             { this.state.validation_state === "error" ? "A graphics method with that name already exists." : null }
                         </HelpBlock>
                     </FormGroup>
-                    <FormGroup controlId="formControlsSelectType">
-                        <ControlLabel>Base Graphics Type</ControlLabel>
-                        <FormControl
-                            componentClass="select"
-                            value={this.state.selected_gm_type}
-                            onChange={(e)=>this.setState({selected_gm_type: e.target.value})}
-                        >
-                        {
-                            Object.keys(this.props.graphics_methods).map((name) => {
-                                return <option key={name} value={name}>{name}</option>
-                            })
-                        }
-                        </FormControl>
-                    </FormGroup>
-                    <FormGroup controlId="formControlsSelectMethod">
-                        <ControlLabel>Base Graphics Method</ControlLabel>
-                        <FormControl
-                            componentClass="select"
-                            value={this.state.selected_gm_method}
-                            onChange={(e)=>this.setState({selected_gm_method: e.target.value})}
-                        >
-                        { this.props.graphics_methods[this.state.selected_gm_type] ?
-                            Object.keys(this.props.graphics_methods[this.state.selected_gm_type]).map((name) => {
-                                return <option key={name} value={name}>{name}</option>
-                            })
-                            :
-                                <option value=""></option>
-                        }
-                        </FormControl>
-                    </FormGroup>
                 </Modal.Body>
                 <Modal.Footer>
                     <Button
                         bsStyle="primary"
                         disabled={this.state.validation_state !== "success" } 
-                        onClick={this.createTemplate}
+                        onClick={this.createGraphicsMethod}
                     >Create
                     </Button>
                     <Button onClick={this.props.close} bsStyle="default">Cancel</Button>    
@@ -157,14 +169,21 @@ GraphicsMethodCreator.propTypes = {
         )
     ),
     createGraphicsMethod: PropTypes.func,
+    selectGraphicsMethod: PropTypes.func,
+}
+
+const mapStateToProps = (state) => {
+    return {
+        gms: state.present.graphics_methods
+    }
 }
 
 const mapDispatchToProps = (dispatch) => {
     return {
-        createGraphicsMethod: (type, name) => {
-            dispatch(Actions.createGraphicsMethod(type, name))
+        createGraphicsMethod: (name, type, base) => {
+            dispatch(Actions.createGraphicsMethod(name, type, base))
         }
     }
 }
 export { GraphicsMethodCreator as PureGraphicsMethodCreator}
-export default connect(null, mapDispatchToProps)(GraphicsMethodCreator);
+export default connect(mapStateToProps, mapDispatchToProps)(GraphicsMethodCreator);

--- a/frontend/src/js/components/modals/GraphicsMethodCreator.jsx
+++ b/frontend/src/js/components/modals/GraphicsMethodCreator.jsx
@@ -31,6 +31,7 @@ class GraphicsMethodCreator extends Component {
             validation_state: null,
             selected_gm_type: default_gm_type,
             selected_gm_method: default_gm_method,
+            error_message: "",
         }
 
         this.createGraphicsMethod = this.createGraphicsMethod.bind(this)
@@ -39,18 +40,25 @@ class GraphicsMethodCreator extends Component {
 
     handleChange(event) {
         const name = event.target.value
-        const validation_state = this.getValidationState(name, this.state.selected_gm_type)
-        this.setState({new_gm_name: name, validation_state: validation_state})
+        const {status: validation_state, message} = this.getValidationState(name, this.state.selected_gm_type)
+        this.setState({new_gm_name: name, validation_state: validation_state, error_message: message})
     }
 
     getValidationState(name, gm_type){
+        // Checks if the given input is a valid name for a new GM
+        // returns an object with the following keys:
+        //    status: A string or null that indicates the validity of the input
+        //    message: A string that contains the error message to display when the status is "error"
         if(name.length === 0 || gm_type === "" ){
-            return null
+            return {status: null, message: ""}
         }
         else if(Object.keys(this.props.graphics_methods[gm_type]).indexOf(name) > -1) {
-            return "error"
+            return {status: "error", message: "A Graphics Method with that name already exists"}
         }
-        return "success"
+        else if(name.startsWith("__")) {
+            return {status: "error", message: "Graphics Method names should not start with two underscores"}
+        }
+        return {status: "success", message: ""}
     }
 
     createGraphicsMethod() {
@@ -98,7 +106,9 @@ class GraphicsMethodCreator extends Component {
                                     onChange={(e)=>this.setState({selected_gm_type: e.target.value})}
                                 >
                                 {
-                                    Object.keys(this.props.graphics_methods).map((name) => {
+                                    Object.keys(this.props.graphics_methods).sort(function (a, b) {
+                                        return a.toLowerCase().localeCompare(b.toLowerCase())
+                                    }).map((name) => {
                                         return <option key={name} value={name}>{name}</option>
                                     })
                                 }
@@ -117,7 +127,9 @@ class GraphicsMethodCreator extends Component {
                                     onChange={(e)=>this.setState({selected_gm_method: e.target.value})}
                                 >
                                 { this.props.graphics_methods[this.state.selected_gm_type] ?
-                                    Object.keys(this.props.graphics_methods[this.state.selected_gm_type]).map((name) => {
+                                    Object.keys(this.props.graphics_methods[this.state.selected_gm_type]).sort(function (a, b) {
+                                        return a.toLowerCase().localeCompare(b.toLowerCase())
+                                    }).map((name) => {
                                         return <option key={name} value={name}>{name}</option>
                                     })
                                     :
@@ -142,7 +154,7 @@ class GraphicsMethodCreator extends Component {
                         />
                         <FormControl.Feedback />
                         <HelpBlock>
-                            { this.state.validation_state === "error" ? "A graphics method with that name already exists." : null }
+                            { this.state.validation_state === "error" ? this.state.error_message : null }
                         </HelpBlock>
                     </FormGroup>
                 </Modal.Body>

--- a/frontend/src/js/components/modals/GraphicsMethodCreator.jsx
+++ b/frontend/src/js/components/modals/GraphicsMethodCreator.jsx
@@ -1,91 +1,94 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import Actions from '../../constants/Actions.js'
-import { Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock, Row, Col} from 'react-bootstrap'
-import { toast } from 'react-toastify'
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import Actions from "../../constants/Actions.js";
+import { Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock, Row, Col } from "react-bootstrap";
+import { toast } from "react-toastify";
 
 class GraphicsMethodCreator extends Component {
-    constructor(props){
-        super(props)
-        let default_gm_type = ""
-        let default_gm_method = ""
-        const gm_types = Object.keys(props.graphics_methods)
+    constructor(props) {
+        super(props);
+        let default_gm_type = "";
+        let default_gm_method = "";
+        const gm_types = Object.keys(props.graphics_methods);
 
-        if(gm_types.length > 0) {
-            default_gm_type = Object.keys(props.graphics_methods)[0] // just grab the first one each time since there isnt really a default
+        if (gm_types.length > 0) {
+            default_gm_type = Object.keys(props.graphics_methods)[0]; // just grab the first one each time since there isnt really a default
         }
 
-        if(default_gm_type){ // can't select a graphics method if the types weren't defined
-            const gm_methods = Object.keys(props.graphics_methods[default_gm_type])
-            if(gm_methods.indexOf("default") >= 0) {
-                default_gm_method = "default"
-            }
-            else if(gm_methods.length > 0) {
-                default_gm_method = gm_methods[0]
+        if (default_gm_type) {
+            // can't select a graphics method if the types weren't defined
+            const gm_methods = Object.keys(props.graphics_methods[default_gm_type]);
+            if (gm_methods.indexOf("default") >= 0) {
+                default_gm_method = "default";
+            } else if (gm_methods.length > 0) {
+                default_gm_method = gm_methods[0];
             }
         }
-        
+
         this.state = {
             new_gm_name: "",
             validation_state: null,
             selected_gm_type: default_gm_type,
             selected_gm_method: default_gm_method,
-            error_message: "",
-        }
+            error_message: ""
+        };
 
-        this.createGraphicsMethod = this.createGraphicsMethod.bind(this)
-        this.handleChange = this.handleChange.bind(this)
+        this.createGraphicsMethod = this.createGraphicsMethod.bind(this);
+        this.handleChange = this.handleChange.bind(this);
+        this.handleKeyPress = this.handleKeyPress.bind(this)
     }
 
     handleChange(event) {
-        const name = event.target.value
-        const {status: validation_state, message} = this.getValidationState(name, this.state.selected_gm_type)
-        this.setState({new_gm_name: name, validation_state: validation_state, error_message: message})
+        const name = event.target.value;
+        const { status: validation_state, message } = this.getValidationState(name, this.state.selected_gm_type);
+        this.setState({ new_gm_name: name, validation_state: validation_state, error_message: message });
     }
 
-    getValidationState(name, gm_type){
+    handleKeyPress(event) {
+        if(event.charCode === 13 && this.state.validation_state === "success") {
+            this.createGraphicsMethod()
+        }
+    }
+
+    getValidationState(name, gm_type) {
         // Checks if the given input is a valid name for a new GM
         // returns an object with the following keys:
         //    status: A string or null that indicates the validity of the input
         //    message: A string that contains the error message to display when the status is "error"
-        if(name.length === 0 || gm_type === "" ){
-            return {status: null, message: ""}
+        if (name.length === 0 || gm_type === "") {
+            return { status: null, message: "" };
+        } else if (Object.keys(this.props.graphics_methods[gm_type]).indexOf(name) > -1) {
+            return { status: "error", message: "A Graphics Method with that name already exists" };
+        } else if (name.startsWith("__")) {
+            return { status: "error", message: "Graphics Method names should not start with two underscores" };
         }
-        else if(Object.keys(this.props.graphics_methods[gm_type]).indexOf(name) > -1) {
-            return {status: "error", message: "A Graphics Method with that name already exists"}
-        }
-        else if(name.startsWith("__")) {
-            return {status: "error", message: "Graphics Method names should not start with two underscores"}
-        }
-        return {status: "success", message: ""}
+        return { status: "success", message: "" };
     }
 
     createGraphicsMethod() {
         try {
             return vcs.creategraphicsmethod(this.state.selected_gm_type, this.state.new_gm_name, this.state.selected_gm_method).then(
                 (/* success */) => {
-                    this.props.createGraphicsMethod(this.state.new_gm_name, this.state.selected_gm_type, this.state.selected_gm_method)
-                    toast.success("Graphics Method created successfully!", {position: toast.POSITION.BOTTOM_CENTER})
-                    this.props.close()
+                    this.props.createGraphicsMethod(this.state.new_gm_name, this.state.selected_gm_type, this.state.selected_gm_method);
+                    toast.success("Graphics Method created successfully!", { position: toast.POSITION.BOTTOM_CENTER });
+                    this.props.close();
                 },
                 /* istanbul ignore next */
-                (error) => {
-                    console.warn("Error while creating Graphics Method: ", error)
-                    try{
-                        toast.error(error.data.exception, {position: toast.POSITION.BOTTOM_CENTER})
-                    }
-                    catch(e){
-                        toast.error("Failed to create Graphics Method", {position: toast.POSITION.BOTTOM_CENTER})
+                error => {
+                    console.warn("Error while creating Graphics Method: ", error);
+                    try {
+                        toast.error(error.data.exception, { position: toast.POSITION.BOTTOM_CENTER });
+                    } catch (e) {
+                        toast.error("Failed to create Graphics Method", { position: toast.POSITION.BOTTOM_CENTER });
                     }
                 }
-            )
-        }
-        catch(e) {
+            );
+        } catch (e) {
             /* istanbul ignore next */
-            console.warn(e)
+            console.warn(e);
             /* istanbul ignore next */
-            toast.error("An error occurred while creating the Graphics Method. Try restarting vCDAT.")
+            toast.error("An error occurred while creating the Graphics Method. Try restarting vCDAT.");
         }
     }
 
@@ -103,19 +106,21 @@ class GraphicsMethodCreator extends Component {
                                 <FormControl
                                     componentClass="select"
                                     value={this.state.selected_gm_type}
-                                    onChange={(e)=>this.setState({selected_gm_type: e.target.value})}
+                                    onChange={e => this.setState({ selected_gm_type: e.target.value })}
                                 >
-                                {
-                                    Object.keys(this.props.graphics_methods).sort(function (a, b) {
-                                        return a.toLowerCase().localeCompare(b.toLowerCase())
-                                    }).map((name) => {
-                                        return <option key={name} value={name}>{name}</option>
-                                    })
-                                }
+                                    {Object.keys(this.props.graphics_methods)
+                                        .sort(function(a, b) {
+                                            return a.toLowerCase().localeCompare(b.toLowerCase());
+                                        })
+                                        .map(name => {
+                                            return (
+                                                <option key={name} value={name}>
+                                                    {name}
+                                                </option>
+                                            );
+                                        })}
                                 </FormControl>
-                                <HelpBlock style={{fontSize: "12px"}}>
-                                    Select a type for your new graphics method
-                                </HelpBlock>
+                                <HelpBlock style={{ fontSize: "12px" }}>Select a type for your new graphics method</HelpBlock>
                             </FormGroup>
                         </Col>
                         <Col sm={6}>
@@ -124,48 +129,42 @@ class GraphicsMethodCreator extends Component {
                                 <FormControl
                                     componentClass="select"
                                     value={this.state.selected_gm_method}
-                                    onChange={(e)=>this.setState({selected_gm_method: e.target.value})}
+                                    onChange={e => this.setState({ selected_gm_method: e.target.value })}
                                 >
-                                { this.props.graphics_methods[this.state.selected_gm_type] ?
-                                    Object.keys(this.props.graphics_methods[this.state.selected_gm_type]).sort(function (a, b) {
-                                        return a.toLowerCase().localeCompare(b.toLowerCase())
-                                    }).map((name) => {
-                                        return <option key={name} value={name}>{name}</option>
-                                    })
-                                    :
-                                        <option value=""></option>
-                                }
+                                    {this.props.graphics_methods[this.state.selected_gm_type] ? (
+                                        Object.keys(this.props.graphics_methods[this.state.selected_gm_type])
+                                            .sort(function(a, b) {
+                                                return a.toLowerCase().localeCompare(b.toLowerCase());
+                                            })
+                                            .map(name => {
+                                                return (
+                                                    <option key={name} value={name}>
+                                                        {name}
+                                                    </option>
+                                                );
+                                            })
+                                    ) : (
+                                        <option value="" />
+                                    )}
                                 </FormControl>
-                                <HelpBlock style={{fontSize: "12px"}}>
-                                    Select an existing graphics method to copy and use as a base.
-                                </HelpBlock>
+                                <HelpBlock style={{ fontSize: "12px" }}>Select an existing graphics method to copy and use as a base.</HelpBlock>
                             </FormGroup>
                         </Col>
                     </Row>
-                    <FormGroup
-                        controlId="formBasicText"
-                        validationState={this.state.validation_state}
-                    >
+                    <FormGroup controlId="formBasicText" validationState={this.state.validation_state}>
                         <ControlLabel>New Graphics Method Name</ControlLabel>
-                        <FormControl
-                            type="text"
-                            value={this.state.new_gm_name}
-                            onChange={this.handleChange}
-                        />
+                        <FormControl type="text" value={this.state.new_gm_name} onKeyPress={this.handleKeyPress} onChange={this.handleChange} />
                         <FormControl.Feedback />
-                        <HelpBlock>
-                            { this.state.validation_state === "error" ? this.state.error_message : null }
-                        </HelpBlock>
+                        <HelpBlock>{this.state.validation_state === "error" ? this.state.error_message : null}</HelpBlock>
                     </FormGroup>
                 </Modal.Body>
                 <Modal.Footer>
-                    <Button
-                        bsStyle="primary"
-                        disabled={this.state.validation_state !== "success" } 
-                        onClick={this.createGraphicsMethod}
-                    >Create
+                    <Button bsStyle="primary" disabled={this.state.validation_state !== "success"} onClick={this.createGraphicsMethod}>
+                        Create
                     </Button>
-                    <Button onClick={this.props.close} bsStyle="default">Cancel</Button>    
+                    <Button onClick={this.props.close} bsStyle="default">
+                        Cancel
+                    </Button>
                 </Modal.Footer>
             </Modal>
         );
@@ -175,27 +174,25 @@ class GraphicsMethodCreator extends Component {
 GraphicsMethodCreator.propTypes = {
     show: PropTypes.bool,
     close: PropTypes.func,
-    graphics_methods: PropTypes.objectOf(
-        PropTypes.objectOf(
-            PropTypes.object
-        )
-    ),
+    graphics_methods: PropTypes.objectOf(PropTypes.objectOf(PropTypes.object)),
     createGraphicsMethod: PropTypes.func,
-    selectGraphicsMethod: PropTypes.func,
-}
+    selectGraphicsMethod: PropTypes.func
+};
 
-const mapStateToProps = (state) => {
+/* istanbul ignore next */
+const mapStateToProps = state => {
     return {
         gms: state.present.graphics_methods
-    }
-}
+    };
+};
 
-const mapDispatchToProps = (dispatch) => {
+/* istanbul ignore next */
+const mapDispatchToProps = dispatch => {
     return {
         createGraphicsMethod: (name, type, base) => {
-            dispatch(Actions.createGraphicsMethod(name, type, base))
+            dispatch(Actions.createGraphicsMethod(name, type, base));
         }
-    }
-}
-export { GraphicsMethodCreator as PureGraphicsMethodCreator}
+    };
+};
+export { GraphicsMethodCreator as PureGraphicsMethodCreator };
 export default connect(mapStateToProps, mapDispatchToProps)(GraphicsMethodCreator);

--- a/frontend/src/js/components/modals/TemplateCreator.jsx
+++ b/frontend/src/js/components/modals/TemplateCreator.jsx
@@ -19,6 +19,7 @@ class TemplateCreator extends Component {
         this.state = {
             new_template_name: "",
             validation_state: null,
+            error_message: "",
             selected_base_template: default_base_template
         }
 
@@ -29,8 +30,8 @@ class TemplateCreator extends Component {
 
     handleChange(event) {
         const name = event.target.value
-        const validation_state = this.getValidationState(name)
-        this.setState({new_template_name: name, validation_state: validation_state})
+        const {status: validation_state, message} = this.getValidationState(name)
+        this.setState({new_template_name: name, validation_state: validation_state, error_message: message})
     }
 
     handleKeyPress(event) {
@@ -41,12 +42,15 @@ class TemplateCreator extends Component {
 
     getValidationState(name){
         if(name.length === 0){
-            return null
+            return {status: null, message: ""}
         }
         else if(this.props.templates.indexOf(name) > -1) {
-            return "error"
+            return {status: "error", message: "A Graphics Method with that name already exists"}
         }
-        return "success"
+        else if(name.startsWith("__")) {
+            return {status: "error", message: "Template names should not start with two underscores"}
+        }
+        return {status: "success", message: ""}
     }
 
     createTemplate() {
@@ -111,7 +115,7 @@ class TemplateCreator extends Component {
                         />
                         <FormControl.Feedback />
                         <HelpBlock>
-                            { this.state.validation_state === "error" ? "A template with that name already exists." : null }
+                            { this.state.validation_state === "error" ? this.state.error_message : null }
                         </HelpBlock>
                     </FormGroup>                    
                 </Modal.Body>

--- a/frontend/src/js/components/modals/TemplateCreator.jsx
+++ b/frontend/src/js/components/modals/TemplateCreator.jsx
@@ -45,7 +45,7 @@ class TemplateCreator extends Component {
             return {status: null, message: ""}
         }
         else if(this.props.templates.indexOf(name) > -1) {
-            return {status: "error", message: "A Graphics Method with that name already exists"}
+            return {status: "error", message: "A Template with that name already exists"}
         }
         else if(name.startsWith("__")) {
             return {status: "error", message: "Template names should not start with two underscores"}

--- a/frontend/src/js/constants/Actions.js
+++ b/frontend/src/js/constants/Actions.js
@@ -191,6 +191,13 @@ var Actions = {
             transforms: transforms,
         }
     },
+    createGraphicsMethod(name, gm_type, base_method) {
+        return {
+            type: "CREATE_GRAPHICS_METHOD",
+            gm_type: gm_type,
+            base_method: base_method
+        }
+    },
     updateGraphicsMethod(graphics_method) {
         return {
             type: 'UPDATE_GRAPHICS_METHOD',

--- a/frontend/src/js/constants/Actions.js
+++ b/frontend/src/js/constants/Actions.js
@@ -194,8 +194,16 @@ var Actions = {
     createGraphicsMethod(name, gm_type, base_method) {
         return {
             type: "CREATE_GRAPHICS_METHOD",
+            name: name,
             gm_type: gm_type,
-            base_method: base_method
+            method: base_method
+        }
+    },
+    selectGraphicsMethod(type, method){
+        return {
+            type: "SELECT_GRAPHICS_METHOD",
+            gm_type: type,
+            method: method
         }
     },
     updateGraphicsMethod(graphics_method) {

--- a/frontend/src/js/constants/Actions.js
+++ b/frontend/src/js/constants/Actions.js
@@ -196,10 +196,10 @@ var Actions = {
             type: "CREATE_GRAPHICS_METHOD",
             name: name,
             gm_type: gm_type,
-            method: base_method
+            base_method: base_method
         }
     },
-    selectGraphicsMethod(type, method){
+    selectGraphicsMethod(type, method) {
         return {
             type: "SELECT_GRAPHICS_METHOD",
             gm_type: type,
@@ -210,6 +210,13 @@ var Actions = {
         return {
             type: 'UPDATE_GRAPHICS_METHOD',
             graphics_method
+        }
+    },
+    removeGraphicsMethod(gm_type, name) {
+        return {
+            type: 'REMOVE_GRAPHICS_METHOD',
+            gm_type: gm_type,
+            name: name
         }
     },
     initializeColormaps(colormaps) {

--- a/frontend/src/js/containers/LeftSideBar.jsx
+++ b/frontend/src/js/containers/LeftSideBar.jsx
@@ -19,10 +19,13 @@ class LeftSideBar extends Component {
                     selectVariable={this.props.selectVariable}
                     selected_variable={this.props.selected_variable}
                 />
-                <GMList graphicsMethods={this.props.graphics_methods}
+                <GMList 
                     updateGraphicsMethod={this.props.updateGraphicsMethod}
                     colormaps={this.props.colormaps}
                     defaultMethods={this.props.default_methods}
+                    selected_graphics_type={this.props.selected_graphics_type}
+                    selected_graphics_method={this.props.selected_graphics_method}
+                    selectGraphicsMethod={this.props.selectGraphicsMethod}
                 />
                 <TemplateList
                     templates={this.props.templates}
@@ -38,7 +41,7 @@ class LeftSideBar extends Component {
 LeftSideBar.propTypes ={
     cached_files: PropTypes.object,
     getColormaps: PropTypes.func,
-    graphics_methods: PropTypes.object,
+    
     loadVariables: PropTypes.func,
     templates: PropTypes.arrayOf(PropTypes.string),
     variables: PropTypes.oneOfType([
@@ -47,7 +50,6 @@ LeftSideBar.propTypes ={
     ]),
     colormaps: PropTypes.object,
     sheets_model: PropTypes.object,
-    updateGraphicsMethods: PropTypes.func,
     selectTemplate: PropTypes.func,
     selected_template: PropTypes.string,
     updateTemplate: PropTypes.func,
@@ -60,9 +62,8 @@ LeftSideBar.propTypes ={
 const mapStateToProps = (state) => {
     return {
         variables: state.present.variables,
-        graphics_methods: state.present.graphics_methods,
-        templates: state.present.templates.names,
-        selected_template: state.present.templates.selected_template,
+        templates: state.present.templates,
+        selected_template: state.present.ui.selected_template,
         cached_files: state.present.cached_files,
         sheets_model: state.present.sheets_model,
         colormaps: state.present.colormaps,
@@ -82,9 +83,7 @@ const mapDispatchToProps = (dispatch) => {
                 // error handling here. No variable selected when delete was pressed
             }
         },
-        updateGraphicsMethod: (graphics_method) => {
-            dispatch(Actions.updateGraphicsMethod(graphics_method))
-        },
+        
         selectTemplate: (name) => dispatch(Actions.selectTemplate(name)),
         updateTemplate: (template) => dispatch(Actions.updateTemplate(template)),
         removeTemplate: (name) => dispatch(Actions.removeTemplate(name)),

--- a/frontend/src/js/models/GraphicsMethods.js
+++ b/frontend/src/js/models/GraphicsMethods.js
@@ -45,6 +45,7 @@ class GraphicsMethodModel extends BaseModel {
             case "CREATE_GRAPHICS_METHOD":
                 new_graphics_methods = $.extend(true, {}, state)
                 new_graphics_methods[action.gm_type][action.name] = $.extend(true, {}, new_graphics_methods[action.gm_type][action.base_method])
+                new_graphics_methods[action.gm_type][action.name].name = action.name
                 return new_graphics_methods
             case "REMOVE_GRAPHICS_METHOD":
                 new_graphics_methods = $.extend(true, {}, state)
@@ -72,7 +73,18 @@ class GraphicsMethodModel extends BaseModel {
 
     static getInitialState() {
         try {
-            return vcs.getallgraphicsmethods() 
+            return vcs.getallgraphicsmethods().then((methods) => {
+                // search through each gm type and check if any names start with "__"
+                // If any are found, they are removed from being displayed since they are temporary names
+                for(let type of Object.keys(methods)){
+                    for(let name of Object.keys(methods[type])){
+                        if(name.startsWith("__")){
+                            delete methods[type][name]
+                        }
+                    }
+                }
+                return methods
+            })
         }
         catch(e){
             console.warn(e)

--- a/frontend/src/js/models/GraphicsMethods.js
+++ b/frontend/src/js/models/GraphicsMethods.js
@@ -46,6 +46,15 @@ class GraphicsMethodModel extends BaseModel {
                 new_graphics_methods = $.extend(true, {}, state)
                 new_graphics_methods[action.gm_type][action.name] = $.extend(true, {}, new_graphics_methods[action.gm_type][action.base_method])
                 return new_graphics_methods
+            case "REMOVE_GRAPHICS_METHOD":
+                new_graphics_methods = $.extend(true, {}, state)
+                try {
+                    delete new_graphics_methods[action.gm_type][action.name]
+                }
+                catch(e) {
+                    console.warn(e)
+                }
+                return new_graphics_methods
             case "DELETE_COLORMAP":
                 new_graphics_methods = Object.assign({}, state)
                 for(let type of Object.keys(new_graphics_methods)){
@@ -62,7 +71,13 @@ class GraphicsMethodModel extends BaseModel {
     }
 
     static getInitialState() {
-        return vcs.getallgraphicsmethods() 
+        try {
+            return vcs.getallgraphicsmethods() 
+        }
+        catch(e){
+            console.warn(e)
+            return {}
+        }
     }
 
 }

--- a/frontend/src/js/models/GraphicsMethods.js
+++ b/frontend/src/js/models/GraphicsMethods.js
@@ -42,6 +42,10 @@ class GraphicsMethodModel extends BaseModel {
                         break;
                 }
                 return new_graphics_methods;
+            case "CREATE_GRAPHICS_METHOD":
+                new_graphics_methods = $.extend(true, {}, state)
+                new_graphics_methods[action.gm_type][action.name] = $.extend(true, {}, new_graphics_methods[action.gm_type][action.base_method])
+                return new_graphics_methods
             case "DELETE_COLORMAP":
                 new_graphics_methods = Object.assign({}, state)
                 for(let type of Object.keys(new_graphics_methods)){
@@ -58,7 +62,7 @@ class GraphicsMethodModel extends BaseModel {
     }
 
     static getInitialState() {
-        return $.get("getGraphicsMethods");
+        return vcs.getallgraphicsmethods() 
     }
 
 }

--- a/frontend/src/js/models/Templates.js
+++ b/frontend/src/js/models/Templates.js
@@ -33,7 +33,7 @@ class TemplateModel extends BaseModel {
     static getInitialState() {
         try{
             return vcs.getalltemplatenames().then((names) => {
-                return names // ["ASD", "default"] etc
+                return names.filter((name) => {return !name.startsWith("__")}) // ["ASD", "default"] etc. filter out temp names like "__boxfill_12345"
             })
         }
         catch(e){

--- a/frontend/src/js/models/Templates.js
+++ b/frontend/src/js/models/Templates.js
@@ -1,5 +1,6 @@
-import BaseModel from './BaseModel.js';
+import BaseModel from './BaseModel.js'
 import { toast } from 'react-toastify'
+import $ from 'jquery'
 
 class TemplateModel extends BaseModel {
     static reduce(state={}, action) {
@@ -7,29 +8,21 @@ class TemplateModel extends BaseModel {
         switch (action.type) {
             case 'INITIALIZE_TEMPLATE_VALUES':
                 return action.templates;
-            case 'SELECT_TEMPLATE':
-                new_state = $.extend(true, {}, state);
-                new_state.selected_template = action.selected_template
-                return new_state
             case 'CREATE_TEMPLATE':
-                new_state = $.extend(true, {}, state);
-                for(let i=0; i < new_state.names.length; i++){
-                    if(new_state.names[i].toLocaleLowerCase() > action.name.toLocaleLowerCase()){
-                        new_state.names.splice(i, 0, action.name) // inserts name into alphabetical index
-                        new_state.selected_template = action.name
+                new_state = $.extend(true, [], state);
+                for(let i=0; i < new_state.length; i++){
+                    if(new_state[i].toLocaleLowerCase() > action.name.toLocaleLowerCase()){
+                        new_state.splice(i, 0, action.name) // inserts name into alphabetical index
                         break
                     }
                 }
                 return new_state
             case 'REMOVE_TEMPLATE':
-                new_state = $.extend(true, {}, state);
-                new_state.names.splice(new_state.names.indexOf(action.name), 1)
-                if(new_state.names.indexOf(new_state.selected_template) === -1){
-                    new_state.selected_template = ""
-                }
+                new_state = $.extend(true, [], state);
+                new_state.splice(new_state.indexOf(action.name), 1)
                 return new_state
             case 'UPDATE_TEMPLATE':
-                new_state = $.extend(true, {}, state);
+                new_state = $.extend(true, [], state);
                 new_state[action.template.name] = action.template;
                 return new_state;
             default:
@@ -40,10 +33,7 @@ class TemplateModel extends BaseModel {
     static getInitialState() {
         try{
             return vcs.getalltemplatenames().then((names) => {
-                return {
-                    names: names,
-                    selected_template: ""
-                }
+                return names // ["ASD", "default"] etc
             })
         }
         catch(e){
@@ -54,7 +44,7 @@ class TemplateModel extends BaseModel {
             else{
                 console.warn(e)
             }
-            return {names: [], selected_template: ""}
+            return []
         }
         
     }

--- a/frontend/src/js/models/UI.js
+++ b/frontend/src/js/models/UI.js
@@ -21,7 +21,6 @@ class UIModel extends BaseModel {
                 return new_state
             case "CREATE_GRAPHICS_METHOD":
                 new_state = $.extend(true, {}, state);
-                console.log(action)
                 new_state.selected_graphics_method = action.name
                 new_state.selected_graphics_type= action.gm_type
                 return new_state

--- a/frontend/src/js/models/UI.js
+++ b/frontend/src/js/models/UI.js
@@ -1,0 +1,47 @@
+import BaseModel from './BaseModel.js';
+import $ from 'jquery'
+
+class UIModel extends BaseModel {
+    static reduce(state={}, action) {
+        let new_state;
+        switch (action.type) {
+            case 'CREATE_TEMPLATE':
+                new_state = $.extend(true, {}, state);
+                new_state.selected_template = action.name
+                return new_state
+            case 'SELECT_TEMPLATE':
+                new_state = $.extend(true, {}, state);
+                new_state.selected_template = action.selected_template
+                return new_state
+            case 'REMOVE_TEMPLATE':
+                new_state = $.extend(true, {}, state);
+                if(new_state.selected_template === action.name){
+                    new_state.selected_template = ""
+                }
+                return new_state
+            case "CREATE_GRAPHICS_METHOD":
+                new_state = $.extend(true, {}, state);
+                console.log(action)
+                new_state.selected_graphics_method = action.name
+                new_state.selected_graphics_type= action.gm_type
+                return new_state
+            case "SELECT_GRAPHICS_METHOD":
+                new_state = $.extend(true, {}, state);
+                new_state.selected_graphics_method = action.method
+                new_state.selected_graphics_type= action.gm_type
+                return new_state
+            default:
+                return state;
+        }
+    }
+
+    static getInitialState() {
+        return {
+            selected_template: "",
+            selected_graphics_type: "",
+            selected_graphics_method: "",
+        }
+    }
+}
+
+export default UIModel

--- a/frontend/test/mocha/components/Modals/GraphicsMethodCreatorTest.jsx
+++ b/frontend/test/mocha/components/Modals/GraphicsMethodCreatorTest.jsx
@@ -1,0 +1,175 @@
+/* globals it, describe, before, beforeEach, */
+let chai = require("chai");
+let expect = chai.expect;
+let React = require("react");
+
+import { PureGraphicsMethodCreator as GraphicsMethodCreator } from "../../../../src/js/components/modals/GraphicsMethodCreator.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import sinon from "sinon";
+
+const getProps = function() {
+    return {
+        show: true,
+        close: sinon.spy(),
+        graphics_methods: {
+            boxfill: {
+                default: { name: "default" },
+                polar: { name: "polar" },
+                quick: { name: "quick" }
+            },
+            isofill: {
+                default: { name: "default" },
+                polar: { name: "polar" },
+                quick: { name: "quick" }
+            }
+        },
+        createGraphicsMethod: sinon.spy(),
+        selectGraphicsMethod: sinon.spy()
+    };
+};
+
+describe("GraphicsMethodCreatorTest.jsx", function() {
+    it("renders without exploding", () => {
+        let props = getProps();
+        let gm_creator = shallow(<GraphicsMethodCreator {...props} />);
+        expect(gm_creator).to.have.lengthOf(1);
+    });
+
+    it("Sets default gm type and method when default is present", () => {
+        let props = getProps();
+        let gm_creator = shallow(<GraphicsMethodCreator {...props} />);
+        expect(gm_creator.state().selected_gm_type).to.equal("boxfill");
+        expect(gm_creator.state().selected_gm_method).to.equal("default");
+    });
+
+    it("Sets default gm type and method when default is not present", () => {
+        let props = getProps();
+        props.graphics_methods = {
+            boxfill: {
+                polar: { name: "polar" },
+                quick: { name: "quick" }
+            },
+            isofill: {
+                polar: { name: "polar" },
+                quick: { name: "quick" }
+            }
+        };
+        let gm_creator = shallow(<GraphicsMethodCreator {...props} />);
+        expect(gm_creator.state().selected_gm_type).to.equal("boxfill");
+        expect(gm_creator.state().selected_gm_method).to.equal("polar");
+    });
+
+    it("getValidationState works", () => {
+        let props = getProps();
+        let gm_creator = shallow(<GraphicsMethodCreator {...props} />);
+
+        expect(gm_creator.instance().getValidationState("", "")).to.deep.equal({ status: null, message: "" }); // returns null if no name length
+        expect(gm_creator.instance().getValidationState("default", "boxfill")).to.deep.equal({
+            status: "error",
+            message: "A Graphics Method with that name already exists"
+        });
+        expect(gm_creator.instance().getValidationState("polar", "boxfill")).to.deep.equal({
+            status: "error",
+            message: "A Graphics Method with that name already exists"
+        });
+        expect(gm_creator.instance().getValidationState("quick", "boxfill")).to.deep.equal({
+            status: "error",
+            message: "A Graphics Method with that name already exists"
+        });
+        expect(gm_creator.instance().getValidationState("default", "isofill")).to.deep.equal({
+            status: "error",
+            message: "A Graphics Method with that name already exists"
+        });
+        expect(gm_creator.instance().getValidationState("polar", "isofill")).to.deep.equal({
+            status: "error",
+            message: "A Graphics Method with that name already exists"
+        });
+        expect(gm_creator.instance().getValidationState("quick", "isofill")).to.deep.equal({
+            status: "error",
+            message: "A Graphics Method with that name already exists"
+        });
+        expect(gm_creator.instance().getValidationState("__temp", "boxfill")).to.deep.equal({
+            status: "error",
+            message: "Graphics Method names should not start with two underscores"
+        });
+        expect(gm_creator.instance().getValidationState("test", "boxfill")).to.deep.equal({ status: "success", message: "" });
+        expect(gm_creator.instance().getValidationState("valid", "boxfill")).to.deep.equal({ status: "success", message: "" });
+    });
+
+    it("handleChange function sets state", () => {
+        let props = getProps();
+        let gm_creator = shallow(<GraphicsMethodCreator {...props} />);
+        const event_with_null_validation = {
+            target: {
+                value: ""
+            }
+        };
+        const event_with_error_validation = {
+            target: {
+                value: "default"
+            }
+        };
+        const event_with_success_validation = {
+            target: {
+                value: "valid"
+            }
+        };
+        gm_creator.setState({ selected_gm_type: "boxfill" });
+        gm_creator.instance().handleChange(event_with_null_validation);
+        expect(gm_creator.state().new_gm_name).to.equal("");
+        expect(gm_creator.state().validation_state).to.equal(null);
+
+        gm_creator.instance().handleChange(event_with_error_validation);
+        expect(gm_creator.state().new_gm_name).to.equal("default");
+        expect(gm_creator.state().validation_state).to.equal("error");
+
+        gm_creator.instance().handleChange(event_with_success_validation);
+        expect(gm_creator.state().new_gm_name).to.equal("valid");
+        expect(gm_creator.state().validation_state).to.equal("success");
+    });
+
+    it("createGraphicsMethod works", () => {
+        global.vcs = {
+            creategraphicsmethod: sinon.stub().resolves()
+        };
+        const state = {
+            selected_gm_type: "boxfill",
+            new_gm_name: "test_name",
+            selected_gm_method: "default"
+        };
+        let props = getProps();
+        props.createGraphicsMethod = sinon.spy();
+        let gm_creator = shallow(<GraphicsMethodCreator {...props} />);
+        gm_creator.setState(state);
+        return gm_creator
+            .instance()
+            .createGraphicsMethod()
+            .then(() => {
+                expect(vcs.creategraphicsmethod.callCount).to.equal(1);
+                expect(vcs.creategraphicsmethod.getCall(0).args[0]).to.equal(state.selected_gm_type);
+                expect(vcs.creategraphicsmethod.getCall(0).args[1]).to.equal(state.new_gm_name);
+                expect(vcs.creategraphicsmethod.getCall(0).args[2]).to.equal(state.selected_gm_method);
+                expect(props.close.callCount).to.equal(1);
+            });
+    });
+
+    it("handleKeyPress only causes a save when valid", () => {
+        let props = getProps()
+        let gm_creator = shallow(<GraphicsMethodCreator {...props} />)
+        let stub = sinon.stub(gm_creator.instance(), "createGraphicsMethod").callsFake(() => {});
+        gm_creator.setState({ validation_state: "error" });
+        gm_creator.instance().handleKeyPress({ charCode: 100 });
+        expect(stub.callCount).to.equal(0); // should not be called with keys besides enter
+        gm_creator.instance().handleKeyPress({ charCode: 13 }); // 13 is the 'enter' key
+        expect(stub.callCount).to.equal(0); // should not be called with inwvalid name
+
+        gm_creator.setState({ validation_state: "success" });
+        gm_creator.instance().handleKeyPress({ charCode: 100 });
+        expect(stub.callCount).to.equal(0); // should not be called with keys besides enter
+        gm_creator.instance().handleKeyPress({ charCode: 13 });
+        expect(stub.callCount).to.equal(1); // should be called now that validation is 'success'
+    });
+});

--- a/frontend/test/mocha/components/Modals/TemplateCreatorTest.jsx
+++ b/frontend/test/mocha/components/Modals/TemplateCreatorTest.jsx
@@ -1,127 +1,141 @@
 /* globals it, describe, before, beforeEach, */
-var chai = require('chai')
+var chai = require("chai");
 var expect = chai.expect;
-var React = require('react')
+var React = require("react");
 
-import TemplateCreator from '../../../../src/js/components/modals/TemplateCreator.jsx'
-import Enzyme from 'enzyme' 
-import Adapter from 'enzyme-adapter-react-16'
-Enzyme.configure({ adapter: new Adapter() })
-import { shallow, mount } from 'enzyme'
-import sinon from 'sinon'
-import { createMockStore } from 'redux-test-utils'
+import TemplateCreator from "../../../../src/js/components/modals/TemplateCreator.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import sinon from "sinon";
+import { createMockStore } from "redux-test-utils";
 
-const getProps = function(){
+const getProps = function() {
     return {
         show: true,
         close: sinon.spy(),
         templates: ["ASD", "default", "quick"],
         createTemplate: sinon.spy(),
         store: createMockStore({})
-    }
-}
+    };
+};
 
-describe('TemplateCreatorTest.jsx', function() {
-    it('renders without exploding', () => {
-        let props = getProps()
-        var template_creator = shallow(<TemplateCreator {...props} />)
-        expect(template_creator).to.have.lengthOf(1)
+describe("TemplateCreatorTest.jsx", function() {
+    it("renders without exploding", () => {
+        let props = getProps();
+        var template_creator = shallow(<TemplateCreator {...props} />);
+        expect(template_creator).to.have.lengthOf(1);
     });
 
     it('Sets default base template if no template named "default" exists', () => {
-        let props = getProps()
-        props.templates = ["ASD", "quick"]
-        var template_creator = shallow(<TemplateCreator {...props} />).dive()
-        expect(template_creator.state().selected_base_template).to.equal("ASD")
-    });
-    
-
-    it('getValidationState works', () => {
-        let props = getProps()
-        var template_creator = shallow(<TemplateCreator {...props} />).dive()
-
-        expect(template_creator.instance().getValidationState("")).to.equal(null) // returns null if no name length
-        expect(template_creator.instance().getValidationState("ASD")).to.equal("error")
-        expect(template_creator.instance().getValidationState("default")).to.equal("error")
-        expect(template_creator.instance().getValidationState("quick")).to.equal("error")
-        expect(template_creator.instance().getValidationState("test")).to.equal("success")
-        expect(template_creator.instance().getValidationState("valid")).to.equal("success")
+        let props = getProps();
+        props.templates = ["ASD", "quick"];
+        var template_creator = shallow(<TemplateCreator {...props} />).dive();
+        expect(template_creator.state().selected_base_template).to.equal("ASD");
     });
 
-    it('handleChange function works', () => {
-        let props = getProps()
-        var template_creator = shallow(<TemplateCreator {...props} />).dive()
+    it("getValidationState works", () => {
+        let props = getProps();
+        var template_creator = shallow(<TemplateCreator {...props} />).dive();
+
+        expect(template_creator.instance().getValidationState("")).to.deep.equal({ status: null, message: "" }); // returns null if no name length
+        expect(template_creator.instance().getValidationState("ASD")).to.deep.equal({
+            status: "error",
+            message: "A Template with that name already exists"
+        });
+        expect(template_creator.instance().getValidationState("default")).to.deep.equal({
+            status: "error",
+            message: "A Template with that name already exists"
+        });
+        expect(template_creator.instance().getValidationState("quick")).to.deep.equal({
+            status: "error",
+            message: "A Template with that name already exists"
+        });
+        expect(template_creator.instance().getValidationState("__temp")).to.deep.equal({
+            status: "error",
+            message: "Template names should not start with two underscores"
+        });
+        expect(template_creator.instance().getValidationState("test")).to.deep.equal({ status: "success", message: "" });
+        expect(template_creator.instance().getValidationState("valid")).to.deep.equal({ status: "success", message: "" });
+    });
+
+    it("handleChange function works", () => {
+        let props = getProps();
+        var template_creator = shallow(<TemplateCreator {...props} />).dive();
         const event_with_null_validation = {
             target: {
                 value: ""
             }
-        }
+        };
         const event_with_error_validation = {
             target: {
                 value: "ASD"
             }
-        }
+        };
         const event_with_success_validation = {
             target: {
                 value: "valid"
             }
-        }
+        };
 
-        template_creator.instance().handleChange(event_with_null_validation)
-        expect(template_creator.state().new_template_name).to.equal("")
-        expect(template_creator.state().validation_state).to.equal(null)
+        template_creator.instance().handleChange(event_with_null_validation);
+        expect(template_creator.state().new_template_name).to.equal("");
+        expect(template_creator.state().validation_state).to.equal(null);
 
-        template_creator.instance().handleChange(event_with_error_validation)
-        expect(template_creator.state().new_template_name).to.equal("ASD")
-        expect(template_creator.state().validation_state).to.equal("error")
+        template_creator.instance().handleChange(event_with_error_validation);
+        expect(template_creator.state().new_template_name).to.equal("ASD");
+        expect(template_creator.state().validation_state).to.equal("error");
 
-        template_creator.instance().handleChange(event_with_success_validation)
-        expect(template_creator.state().new_template_name).to.equal("valid")
-        expect(template_creator.state().validation_state).to.equal("success")
+        template_creator.instance().handleChange(event_with_success_validation);
+        expect(template_creator.state().new_template_name).to.equal("valid");
+        expect(template_creator.state().validation_state).to.equal("success");
     });
 
-    it('createTemplate works', () => {
+    it("createTemplate works", () => {
         global.vcs = {
             createtemplate: sinon.stub().resolves()
-        }
+        };
         let props = {
             show: true,
             close: sinon.spy(),
             templates: ["ASD", "default", "quick"],
             createTemplate: sinon.spy(),
             store: createMockStore({})
-        }
-        var template_creator = shallow(<TemplateCreator {...props} />).dive()
-        template_creator.setState({new_template_name: "test_name"})
-        return template_creator.instance().createTemplate().then(() => {
-            expect(vcs.createtemplate.callCount).to.equal(1)
-            expect(vcs.createtemplate.getCall(0).args[0]).to.equal("test_name")
-            expect(vcs.createtemplate.getCall(0).args[1]).to.equal("default")
-            expect(props.close.callCount).to.equal(1)
-        })
+        };
+        var template_creator = shallow(<TemplateCreator {...props} />).dive();
+        template_creator.setState({ new_template_name: "test_name" });
+        return template_creator
+            .instance()
+            .createTemplate()
+            .then(() => {
+                expect(vcs.createtemplate.callCount).to.equal(1);
+                expect(vcs.createtemplate.getCall(0).args[0]).to.equal("test_name");
+                expect(vcs.createtemplate.getCall(0).args[1]).to.equal("default");
+                expect(props.close.callCount).to.equal(1);
+            });
     });
 
-    it('handleKeyPress only causes a save when valid', () => {
+    it("handleKeyPress only causes a save when valid", () => {
         let props = {
             show: true,
             close: sinon.spy(),
             templates: ["ASD", "default", "quick"],
             createTemplate: sinon.spy(),
             store: createMockStore({})
-        }
-        var template_creator = shallow(<TemplateCreator {...props} />).dive() // fuuuuuu
-        let stub = sinon.stub(template_creator.instance(), 'createTemplate').callsFake(() => {})
-        template_creator.instance().forceUpdate()
-        template_creator.setState({validation_state: "error"})
-        template_creator.instance().handleKeyPress({charCode: 13}) // 13 is the 'enter' key
-        expect(stub.callCount).to.equal(0) // should not be called with invalid name
-        template_creator.instance().handleKeyPress({charCode: 100})
-        expect(stub.callCount).to.equal(0) // should not be called with keys besides enter
+        };
+        var template_creator = shallow(<TemplateCreator {...props} />).dive();
+        let stub = sinon.stub(template_creator.instance(), "createTemplate").callsFake(() => {});
+        template_creator.setState({ validation_state: "error" });
+        template_creator.instance().handleKeyPress({ charCode: 100 });
+        expect(stub.callCount).to.equal(0); // should not be called with keys besides enter
+        template_creator.instance().handleKeyPress({ charCode: 13 }); // 13 is the 'enter' key
+        expect(stub.callCount).to.equal(0); // should not be called with invalid name
 
-        template_creator.setState({validation_state: "success"})
-        template_creator.instance().handleKeyPress({charCode: 100})
-        expect(stub.callCount).to.equal(0) // should not be called with keys besides enter
-        template_creator.instance().handleKeyPress({charCode: 13})
-        expect(stub.callCount).to.equal(1) // should be called now that validation is 'success'
+        template_creator.setState({ validation_state: "success" });
+        template_creator.instance().handleKeyPress({ charCode: 100 });
+        expect(stub.callCount).to.equal(0); // should not be called with keys besides enter
+        template_creator.instance().handleKeyPress({ charCode: 13 });
+        expect(stub.callCount).to.equal(1); // should be called now that validation is 'success'
     });
 });


### PR DESCRIPTION
Moves graphics methods from the flask server to vcs-js.
Adds components to handle creating and deleting GMs.
Adds testing for said components. 
Also adds a couple settings for 'prettier' to begin enforcing a code style consistently. 