### PR TITLE
Calculator

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,31 +1,33 @@
 ## Testing
 
 ### New Tests
-* Add Test to `test_flask.py` in `backend/vcdat/test_flask.py`
+
+- Add Test to `test_flask.py` in `backend/vcdat/test_flask.py`
 
 ### Reading
-* http://flask.pocoo.org/docs/0.11/testing/
-* http://damyanon.net/flask-series-testing/
-* https://docs.pytest.org/en/latest/getting-started.html#getstarted
 
-### Running the backend tests 
+- http://flask.pocoo.org/docs/0.11/testing/
+- http://damyanon.net/flask-series-testing/
+- https://docs.pytest.org/en/latest/getting-started.html#getstarted
+
+### Running the backend tests
 
     > cd ~/project/vcdat
     > source activate backend/venv
     > pip install -e .[test]
     > python setup.py install
     > py.test
-    
+
     backend/tests/test_flask.py ...........                            [100%]
 
     ======================= 11 passed in 3.24 seconds ========================
 
     OK
-    
+
 ### Coverage
 
-__Make sure the dev dependencies have been installed via the pip command above__
-__Additionally, the coverage code gets confused with relative paths, so installing is the easiest way to get accurate coverage numbers__
+**Make sure the dev dependencies have been installed via the pip command above**
+**Additionally, the coverage code gets confused with relative paths, so installing is the easiest way to get accurate coverage numbers**
 
     > python setup.py install
     > py.test --cov backend/vcdat --cov-report term-missing
@@ -64,3 +66,10 @@ You can generate html files with the coverage report with detailed information a
 ### pep8
 
     > pep8 backend/vcdat
+
+### End to End Selenium Tests
+
+Because the selenium tests are not compatible with headless environments (yet), they are skipped by default.
+Developers can run the Selenium end to end tests manually by adding the `--selenium` option when running the pytest/coverage suites like so: `py.test --selenium`.
+
+_Please note that the tests expect that the vCDAT server is already running on port 5000. If the server is not running, the selenium tests WILL NOT start a server on their own, and the tests will fail._

--- a/backend/vcdat/test_end_to_end.py
+++ b/backend/vcdat/test_end_to_end.py
@@ -1,30 +1,32 @@
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
 import pytest
 
 # Declare Fixtures
-#--------------------------------------------------------------------
+# --------------------------------------------------------------------
+
+
 @pytest.fixture()
 def driver():
     driver = webdriver.Chrome()
+    driver.implicitly_wait(5)
+    driver.get("localhost:5000")
     yield driver
     driver.close()
 
 
-
-
 # End to End testing with Selenium
-#--------------------------------------------------------------------
+# --------------------------------------------------------------------
 
 @pytest.mark.selenium
 def test_server_running(driver):
-    driver = webdriver.Chrome()
-    driver.get("localhost:5000")
     assert "vCDAT" in driver.title
-    driver.close()
+
 
 @pytest.mark.selenium
 def test_variable_loads(driver):
-    
-    driver.get("localhost:5000")
-
+    app = driver.find_element_by_xpath("//div[@id='app']")
+    print("xxx found app xxx")
+    app_container = driver.find_element_by_xpath("//div[@id='app-container']")
+    print("xxx found app_container xxx")

--- a/backend/vcdat/test_end_to_end.py
+++ b/backend/vcdat/test_end_to_end.py
@@ -1,15 +1,30 @@
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
 import pytest
-
 
 # Declare Fixtures
 #--------------------------------------------------------------------
-@pytest.fixture(scope="module")
-def selenium(request):
-    
+@pytest.fixture()
+def driver():
+    driver = webdriver.Chrome()
+    yield driver
+    driver.close()
 
 
 
 
 # End to End testing with Selenium
 #--------------------------------------------------------------------
+
+@pytest.mark.selenium
+def test_server_running(driver):
+    driver = webdriver.Chrome()
+    driver.get("localhost:5000")
+    assert "vCDAT" in driver.title
+    driver.close()
+
+@pytest.mark.selenium
+def test_variable_loads(driver):
+    
+    driver.get("localhost:5000")
 

--- a/backend/vcdat/test_end_to_end.py
+++ b/backend/vcdat/test_end_to_end.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+# Declare Fixtures
+#--------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def selenium(request):
+    
+
+
+
+
+# End to End testing with Selenium
+#--------------------------------------------------------------------
+

--- a/ci-support/conda_upload.sh
+++ b/ci-support/conda_upload.sh
@@ -23,7 +23,7 @@ git clone git://github.com/cdat/conda-recipes
 cd conda-recipes
 # cdat creates issues for build -c cdat confuses package and channel
 ln -s ../conda vcdat
-python ./prep_for_build.py -l 0.7.0
+python ./prep_for_build.py -l 0.8.0
 echo "Building now"
 conda build -c cdat/label/nightly -c conda-forge -c cdat $PKG_NAME
 echo "Uploading"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,19 @@
+# content of conftest.py
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--selenium", action="store_true", default=False, help="Run selenium tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--selenium"):
+        # --selenium was given as a cli option: do not skip selenium tests
+        return
+    skip_selenium = pytest.mark.skip(reason="needs --selenium option to run")
+    for item in items:
+        if "selenium" in item.keywords:
+            item.add_marker(skip_selenium)

--- a/frontend/src/js/components/Canvas.jsx
+++ b/frontend/src/js/components/Canvas.jsx
@@ -1,173 +1,177 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import PubSub from 'pubsub-js'
-import PubSubEvents from '../constants/PubSubEvents.js'
-import _ from 'lodash'
-import { toast } from 'react-toastify'
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import PubSub from "pubsub-js";
+import PubSubEvents from "../constants/PubSubEvents.js";
+import _ from "lodash";
+import { toast } from "react-toastify";
 
-class Canvas extends Component{
-    constructor(props){
-        super(props)
+class Canvas extends Component {
+    constructor(props) {
+        super(props);
     }
 
-    shouldComponentUpdate(next_props){
-        try{
-            if(this.props.onTop !== next_props.onTop){
-                // onTop will change to false if the user drags a var/gm/temp over the cell. 
+    shouldComponentUpdate(next_props) {
+        try {
+            if (this.props.onTop !== next_props.onTop) {
+                // onTop will change to false if the user drags a var/gm/temp over the cell.
                 // We need to render so that the class will change to 'cell-stack-bottom'
-                return true
+                return true;
             }
-            if(next_props.can_plot && next_props.onTop && JSON.stringify(this.props) !== JSON.stringify(next_props)){
+            if (next_props.can_plot && next_props.onTop && JSON.stringify(this.props) !== JSON.stringify(next_props)) {
                 // We need to check for several cases here
                 // 1. we must be able to plot
                 // 2. There is no point in rendering a plot if it is hidden under the plotter
-                // 3. Any prop needs to be different. 
+                // 3. Any prop needs to be different.
                 //      i.e. Dont render the same exact plot just because the parent component rendered. Make sure something changed
-                return true
+                return true;
             }
+        } catch (e) {
+            console.error(e);
         }
-        catch(e){
-            console.error(e)
-        }
-        return false
+        return false;
     }
 
     componentDidMount() {
-        try{
+        try {
             this.canvas = vcs.init(this.div);
-            this.resize_token = PubSub.subscribe(PubSubEvents.resize, this.resetCanvas.bind(this))
-            this.colormap_token = PubSub.subscribe(PubSubEvents.colormap_update, this.handleColormapUpdate.bind(this))
-            this.template_token = PubSub.subscribe(PubSubEvents.template_update, this.handleTemplateUpdate.bind(this))
-        }
-        catch(e){
-            if(e instanceof ReferenceError && e.message == "vcs is not defined"){
-                toast.error("VCS is not defined. Try setting the VCSJS_PORT environment variable and restart vCDAT", 
-                    { position: toast.POSITION.BOTTOM_CENTER }
-                )
-            }
-            else{
-                console.warn(e)
+            this.resize_token = PubSub.subscribe(PubSubEvents.resize, this.resetCanvas.bind(this));
+            this.colormap_token = PubSub.subscribe(PubSubEvents.colormap_update, this.handleColormapUpdate.bind(this));
+            this.template_token = PubSub.subscribe(PubSubEvents.template_update, this.handleTemplateUpdate.bind(this));
+        } catch (e) {
+            if (e instanceof ReferenceError && e.message == "vcs is not defined") {
+                toast.error("VCS is not defined. Try setting the VCSJS_PORT environment variable and restart vCDAT", {
+                    position: toast.POSITION.BOTTOM_CENTER
+                });
+            } else {
+                console.warn(e);
             }
         }
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if(prevProps.onTop === true && this.props.onTop === false){
+        if (prevProps.onTop === true && this.props.onTop === false) {
             // Prevents the plot from rendering again when it is actually being hidden
             // We also show the spinner here. This prevents a flicker effect when dragging a var/gm/temp into a cell and back out
             // The incorrect order, and corrected order are shown below
             // plotter -> empty_plot -> spinner -> filled_plot
             // plotter -> spinner -> filled_plot
-            this.spinner.className = "canvas-spinner-show"
-            return
+            this.spinner.className = "canvas-spinner-show";
+            return;
         }
         this.canvas.clear().then(() => {
-            if(this.props.can_plot){
-                this.spinner.className = "canvas-spinner-show"
-                this.plotAll.call(this)
+            if (this.props.can_plot) {
+                this.spinner.className = "canvas-spinner-show";
+                this.plotAll.call(this);
             }
-        })
+        });
     }
 
-    async plotAll(){
-        for(let [index, plot] of this.props.plots.entries()){
-            await this.plot(plot, index)
+    async plotAll() {
+        for (let [index, plot] of this.props.plots.entries()) {
+            await this.plot(plot, index);
         }
-        this.spinner.className = "canvas-spinner-hidden"
+        this.spinner.className = "canvas-spinner-hidden";
     }
 
-    plot(plot, index){
+    plot(plot, index) {
         if (plot.variables.length > 0) {
-            var variables = this.props.plotVariables[index]
-            var dataSpecs = variables.map(function (variable) {
-                var dataSpec = {
-                    uri: variable.path,
-                    variable: variable.cdms_var_name 
+            var variables = this.props.plotVariables[index];
+            var dataSpecs = variables.map(function(variable) {
+                var dataSpec;
+                if (variable.json) {
+                    dataSpec = {
+                        uri: variable.path,
+                        variable: variable.cdms_var_name,
+                        json: variable.json
+                    };
+                } else {
+                    dataSpec = {
+                        uri: variable.path,
+                        variable: variable.cdms_var_name
+                    };
                 }
-                var subRegion = {}
-                variable.dimension
-                    .filter(dimension => dimension.values)
-                    .forEach((dimension) => {
-                        subRegion[dimension.axisName] = dimension.values.range
-                    })
+
+                var subRegion = {};
+                variable.dimension.filter(dimension => dimension.values).forEach(dimension => {
+                    subRegion[dimension.axisName] = dimension.values.range;
+                });
                 if (!_.isEmpty(subRegion)) {
-                    dataSpec['operations'] = [{ subRegion }]
+                    dataSpec["operations"] = [{ subRegion }];
                 }
-                if(!_.isEmpty(variable.transforms)){
-                    if (!dataSpec['operations']) {
-                        dataSpec['operations'] = []
+                if (!_.isEmpty(variable.transforms)) {
+                    if (!dataSpec["operations"]) {
+                        dataSpec["operations"] = [];
                     }
-                    dataSpec['operations'].push({transform: variable.transforms})
+                    dataSpec["operations"].push({ transform: variable.transforms });
                 }
-                var axis_order = variable.dimension.map((dimension) => variable.axisList.indexOf(dimension.axisName))
+                var axis_order = variable.dimension.map(dimension => variable.axisList.indexOf(dimension.axisName));
                 if (axis_order.some((order, index) => order !== index)) {
-                    dataSpec['axis_order'] = axis_order
+                    dataSpec["axis_order"] = axis_order;
                 }
-                return dataSpec
-            })
-            console.log('plotting', dataSpecs, this.props.plotGMs[index], plot.template);
+                return dataSpec;
+            });
+            console.log("plotting", dataSpecs, this.props.plotGMs[index], plot.template);
             return this.canvas.plot(dataSpecs, this.props.plotGMs[index], plot.template).then(
-                (success)=>{
-                    return
+                success => {
+                    return;
                 },
-                (error) =>{
-                    this.canvas.close()
-                    delete this.canvas
+                error => {
+                    this.canvas.close();
+                    delete this.canvas;
                     this.canvas = vcs.init(this.div);
-                    if(error.data){
-                        console.warn("Error while plotting: ", error)
-                        toast.error(error.data.exception, {position: toast.POSITION.BOTTOM_CENTER})
-                    }
-                    else{
-                        console.warn("Unknown error while plotting: ", error)
-                        toast.error("Error while plotting", {position: toast.POSITION.BOTTOM_CENTER})
+                    if (error.data) {
+                        console.warn("Error while plotting: ", error);
+                        toast.error(error.data.exception, { position: toast.POSITION.BOTTOM_CENTER });
+                    } else {
+                        console.warn("Unknown error while plotting: ", error);
+                        toast.error("Error while plotting", { position: toast.POSITION.BOTTOM_CENTER });
                     }
                 }
-            )
+            );
         }
     }
     /* istanbul ignore next */
     componentWillUnmount() {
-        this.canvas.close()
-        PubSub.unsubscribe(this.resize_token)
-        PubSub.unsubscribe(this.colormap_token)
-        PubSub.unsubscribe(this.template_token)
+        this.canvas.close();
+        PubSub.unsubscribe(this.resize_token);
+        PubSub.unsubscribe(this.colormap_token);
+        PubSub.unsubscribe(this.template_token);
     }
 
     /* istanbul ignore next */
-    clearCanvas(){
-        this.canvas.clear()
+    clearCanvas() {
+        this.canvas.clear();
     }
 
     /* istanbul ignore next */
-    resetCanvas(){
-        this.canvas.close()
-        delete this.canvas
-        this.canvas = vcs.init(this.div)
-        this.forceUpdate()
+    resetCanvas() {
+        this.canvas.close();
+        delete this.canvas;
+        this.canvas = vcs.init(this.div);
+        this.forceUpdate();
     }
 
-    handleColormapUpdate(msg, name){
-        let needs_render = false
-        if(this.props.plotGMs && this.props.plotGMs.length > 0){
-            for(let plot of this.props.plotGMs){
-                if(plot.colormap === name){
-                    needs_render = true
-                    break
+    handleColormapUpdate(msg, name) {
+        let needs_render = false;
+        if (this.props.plotGMs && this.props.plotGMs.length > 0) {
+            for (let plot of this.props.plotGMs) {
+                if (plot.colormap === name) {
+                    needs_render = true;
+                    break;
                 }
             }
-            if(needs_render){
-                this.forceUpdate()
+            if (needs_render) {
+                this.forceUpdate();
             }
         }
     }
 
-    handleTemplateUpdate(msg, updated_template){
-        for(let plot of this.props.plots){
-            if(plot.template === updated_template){
-                this.forceUpdate()
-                break
+    handleTemplateUpdate(msg, updated_template) {
+        for (let plot of this.props.plots) {
+            if (plot.template === updated_template) {
+                this.forceUpdate();
+                break;
             }
         }
     }
@@ -175,10 +179,23 @@ class Canvas extends Component{
     render() {
         return (
             <div className={this.props.onTop ? "cell-stack-top" : "cell-stack-bottom"}>
-                <div ref={(el) => {this.div = el}} id={`canvas_${this.props.cell_id}`} className="canvas-container"></div>
-                <div ref={(el) => {this.spinner = el}} className="canvas-spinner-show">Loading <span className="loading-spinner"></span></div>
+                <div
+                    ref={el => {
+                        this.div = el;
+                    }}
+                    id={`canvas_${this.props.cell_id}`}
+                    className="canvas-container"
+                />
+                <div
+                    ref={el => {
+                        this.spinner = el;
+                    }}
+                    className="canvas-spinner-show"
+                >
+                    Loading <span className="loading-spinner" />
+                </div>
             </div>
-        )
+        );
     }
 }
 Canvas.propTypes = {
@@ -191,33 +208,39 @@ Canvas.propTypes = {
     col: PropTypes.number,
     selected_cell_id: PropTypes.string,
     cell_id: PropTypes.string,
-    can_plot: PropTypes.bool,
-}
+    can_plot: PropTypes.bool
+};
 
 const mapStateToProps = (state, ownProps) => {
-    if (!ownProps.can_plot) { // todo: This is old and likely needs to be removed.
+    if (!ownProps.can_plot) {
+        // todo: This is old and likely needs to be removed.
         return {
-            plotVariables: [],
-        }
+            plotVariables: []
+        };
     }
     // When GMs are loaded, use this function to extract them from the state
-    var get_gm_for_plot = (plot) => {
+    var get_gm_for_plot = plot => {
         return state.present.graphics_methods[plot.graphics_method_parent][plot.graphics_method];
     };
 
-    var get_vars_for_plot = (plot) => {
-        return plot.variables.map((variable) => {
+    var get_vars_for_plot = plot => {
+        return plot.variables.map(variable => {
             return state.present.variables[variable];
         });
     };
 
     return {
         plotVariables: ownProps.plots.map(get_vars_for_plot),
-        plotGMs: ownProps.plots.map(get_gm_for_plot),
-    }
-}
-const mapDispatchToProps = (dispatch) => {
-    return {}
-}
+        plotGMs: ownProps.plots.map(get_gm_for_plot)
+    };
+};
+const mapDispatchToProps = dispatch => {
+    return {};
+};
 
-export default connect(mapStateToProps, mapDispatchToProps, null, { withRef: true })(Canvas);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    null,
+    { withRef: true }
+)(Canvas);

--- a/frontend/src/js/components/PlotInspector/PlotInspector.jsx
+++ b/frontend/src/js/components/PlotInspector/PlotInspector.jsx
@@ -1,68 +1,75 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { Button } from 'react-bootstrap'
-import ColormapEditor from "../modals/ColormapEditor/ColormapEditor.jsx"
-import { ONE_VAR_PLOTS } from '../../constants/Constants.js'
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "react-bootstrap";
+import ColormapEditor from "../modals/ColormapEditor/ColormapEditor.jsx";
+import { ONE_VAR_PLOTS } from "../../constants/Constants.js";
 class PlotInspector extends React.PureComponent {
-
     render() {
         return (
             <div className="plot-inspector-wrapper">
-                <div className="tools-container">
+                <div className="tools-container text-center">
                     <div className="tools-header">
                         <p>Tools</p>
-                        <span onClick={this.props.startTour} className="help-button main-help btn btn-xs btn-default"><i className="glyphicon glyphicon-question-sign"></i> Help</span>
+                        <span onClick={this.props.startTour} className="help-button main-help btn btn-xs btn-default">
+                            <i className="glyphicon glyphicon-question-sign" /> Help
+                        </span>
                     </div>
                     <span className="btn-group" role="group">
-                        <button
-                            className='btn btn-default btn-sm'
-                            onClick={this.props.onUndo}
-                            disabled={!this.props.undoEnabled}>
-                            <i className='glyphicon glyphicon-share-alt icon-flipped'></i>
+                        <button className="btn btn-default btn-sm" onClick={this.props.onUndo} disabled={!this.props.undoEnabled}>
+                            <i className="glyphicon glyphicon-share-alt icon-flipped" />
                             <span> Undo</span>
                         </button>
-                        <button
-                            className='btn btn-default btn-sm'
-                            onClick={this.props.onRedo}
-                            disabled={!this.props.redoEnabled}>
-                            <i className='glyphicon glyphicon-share-alt'></i>
+                        <button className="btn btn-default btn-sm" onClick={this.props.onRedo} disabled={!this.props.redoEnabled}>
+                            <i className="glyphicon glyphicon-share-alt" />
                             <span> Redo</span>
                         </button>
-                        <button 
+                        <button
                             id="add-plot-button"
                             className="btn btn-default btn-sm"
                             onClick={this.props.handleAddPlot}
-                            disabled={!(this.props.cell_row > -1 && this.props.cell_col > -1)}>
-                            <i className="glyphicon glyphicon-plus green"></i>
+                            disabled={!(this.props.cell_row > -1 && this.props.cell_col > -1)}
+                        >
+                            <i className="glyphicon glyphicon-plus green" />
                             <span> Add Plot</span>
                         </button>
                     </span>
                     <span className="btn-group" role="group">
-                        <button 
+                        <button
                             id="clear-canvas-button"
                             className="btn btn-default btn-sm material-icons-button"
                             onClick={this.props.handleClearCell}
-                            title="Clear selected plot">
-                            <i className="material-icons" style={{color: "red"}}>clear</i>
+                            title="Clear selected plot"
+                        >
+                            <i className="material-icons" style={{ color: "red" }}>
+                                clear
+                            </i>
                             <span> Clear Cell</span>
                         </button>
-                        <button 
+                        <button
                             id="open-colormap-editor-button"
                             className="btn btn-default btn-sm material-icons-button"
                             onClick={this.props.handleOpenColormapEditor}
-                            title="Open the colormap editor">
-                            <i className="material-icons" style={{color: "blue"}}>color_lens</i>
+                            title="Open the colormap editor"
+                        >
+                            <i className="material-icons" style={{ color: "blue" }}>
+                                color_lens
+                            </i>
                             <span> Colormap Editor</span>
                         </button>
                     </span>
                     <span className="btn-group" role="group">
-                        <button 
+                        <button
                             id="save-plot-button"
                             className="btn btn-default btn-sm material-icons-button"
                             onClick={this.props.handleOpenExportModal}
-                            title="Open the Export Modal">
-                            <i className="material-icons" >save</i>
+                            title="Open the Export Modal"
+                        >
+                            <i className="material-icons">save</i>
                             <span> Export</span>
+                        </button>
+                        <button id="open-calculator-button" className="btn btn-default btn-sm" onClick={this.props.handleOpenCalculator}>
+                            <i className="glyphicon glyphicon-modal-window" />
+                            <span> Calculator</span>
                         </button>
                     </span>
                 </div>
@@ -70,29 +77,40 @@ class PlotInspector extends React.PureComponent {
                     <table className="table table-condensed">
                         <thead>
                             <tr>
-                                <th scope="col" className="no-padding-top delete-col">Delete Plot</th>
-                                <th scope="col" className="no-padding-top">Var 1</th>
-                                <th scope="col" className="no-padding-top">Var 2</th>
-                                <th scope="col" className="no-padding-top">Graphics Type</th>
-                                <th scope="col" className="no-padding-top">Graphics Method</th>
-                                <th scope="col" className="no-padding-top">Template</th>
+                                <th scope="col" className="no-padding-top delete-col">
+                                    Delete Plot
+                                </th>
+                                <th scope="col" className="no-padding-top">
+                                    Var 1
+                                </th>
+                                <th scope="col" className="no-padding-top">
+                                    Var 2
+                                </th>
+                                <th scope="col" className="no-padding-top">
+                                    Graphics Type
+                                </th>
+                                <th scope="col" className="no-padding-top">
+                                    Graphics Method
+                                </th>
+                                <th scope="col" className="no-padding-top">
+                                    Template
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
-                            {
-                                this.props.plots && this.props.plots.map((plot, plot_index) => {
-                                    let cur_var1 = plot.variables.length > 0 ? plot.variables[0] : ""
-                                    let cur_var2 = plot.variables.length > 1 ? plot.variables[1] : ""
-                                    let cur_gm_type = plot.graphics_method_parent
-                                    let cur_gm = plot.graphics_method
-                                    let cur_template = plot.template
-                                    let graphics_methods
-                                    try{
-                                        graphics_methods = Object.keys(this.props.all_graphics_methods[plot.graphics_method_parent])
-                                    }
-                                    catch(e){
-                                        console.warn(e)
-                                        graphics_methods = []
+                            {this.props.plots &&
+                                this.props.plots.map((plot, plot_index) => {
+                                    let cur_var1 = plot.variables.length > 0 ? plot.variables[0] : "";
+                                    let cur_var2 = plot.variables.length > 1 ? plot.variables[1] : "";
+                                    let cur_gm_type = plot.graphics_method_parent;
+                                    let cur_gm = plot.graphics_method;
+                                    let cur_template = plot.template;
+                                    let graphics_methods;
+                                    try {
+                                        graphics_methods = Object.keys(this.props.all_graphics_methods[plot.graphics_method_parent]);
+                                    } catch (e) {
+                                        console.warn(e);
+                                        graphics_methods = [];
                                     }
                                     return (
                                         <tr key={plot_index} className="plot-inspector active">
@@ -101,98 +119,111 @@ class PlotInspector extends React.PureComponent {
                                                     id="delete-plot-button"
                                                     className="glyphicon glyphicon-remove"
                                                     disabled={this.props.disable_delete}
-                                                    onClick={()=>{this.props.handleDeletePlot(plot_index)}}>
-                                                </Button>
+                                                    onClick={() => {
+                                                        this.props.handleDeletePlot(plot_index);
+                                                    }}
+                                                />
                                             </td>
                                             <td>
                                                 <select
                                                     value={cur_var1}
-                                                    onChange={(e)=>this.props.handleSelectVar1(e.target.value, plot_index)}
+                                                    onChange={e => this.props.handleSelectVar1(e.target.value, plot_index)}
                                                     className="form-control"
                                                     id="plot-inspector-variable1-select"
-                                                    >
-                                                    <option value=""></option>
-                                                    {
-                                                        this.props.variables.map((name, index)=>{
-                                                            return <option key={index} value={name}>{name}</option>
-                                                        })
-                                                    }
-                                                </select> 
+                                                >
+                                                    <option value="" />
+                                                    {this.props.variables.map((name, index) => {
+                                                        return (
+                                                            <option key={index} value={name}>
+                                                                {name}
+                                                            </option>
+                                                        );
+                                                    })}
+                                                </select>
                                             </td>
                                             <td>
-                                                <select 
+                                                <select
                                                     value={cur_var2}
-                                                    onChange={(e)=>this.props.handleSelectVar2(e.target.value, plot_index)}
+                                                    onChange={e => this.props.handleSelectVar2(e.target.value, plot_index)}
                                                     className="form-control"
                                                     id="plot-inspector-variable2-select"
                                                     disabled={ONE_VAR_PLOTS.indexOf(cur_gm_type) >= 0}
-                                                    >
-                                                    <option value=""></option>
-                                                    {
-                                                        this.props.variables.map((name, index)=>{
-                                                            return <option key={index} value={name}>{name}</option>
-                                                        })
-                                                    }
+                                                >
+                                                    <option value="" />
+                                                    {this.props.variables.map((name, index) => {
+                                                        return (
+                                                            <option key={index} value={name}>
+                                                                {name}
+                                                            </option>
+                                                        );
+                                                    })}
                                                 </select>
                                             </td>
                                             <td>
-                                                <select 
+                                                <select
                                                     value={cur_gm_type}
-                                                    onChange={(e)=>this.props.handleSelectGMType(e.target.value, plot_index)}
+                                                    onChange={e => this.props.handleSelectGMType(e.target.value, plot_index)}
                                                     className="form-control"
                                                     id="plot-inspector-graphics-method-type-select"
-                                                    >
-                                                    {
-                                                        this.props.graphics_method_types.sort().map((name, index)=>{
-                                                            return <option key={index} value={name}>{name}</option>
-                                                        })
-                                                    }
+                                                >
+                                                    {this.props.graphics_method_types.sort().map((name, index) => {
+                                                        return (
+                                                            <option key={index} value={name}>
+                                                                {name}
+                                                            </option>
+                                                        );
+                                                    })}
                                                 </select>
                                             </td>
                                             <td>
-                                                <select 
+                                                <select
                                                     value={cur_gm}
-                                                    onChange={(e)=>{
-                                                        this.props.handleSelectGM(cur_gm_type, e.target.value, plot_index)
+                                                    onChange={e => {
+                                                        this.props.handleSelectGM(cur_gm_type, e.target.value, plot_index);
                                                     }}
                                                     className="form-control"
                                                     id="plot-inspector-graphics-method-select"
-                                                    >
-                                                    {
-                                                        graphics_methods.sort().map((name, index)=>{
-                                                            return <option key={index} value={name}>{name}</option>
-                                                        })
-                                                    }
+                                                >
+                                                    {graphics_methods.sort().map((name, index) => {
+                                                        return (
+                                                            <option key={index} value={name}>
+                                                                {name}
+                                                            </option>
+                                                        );
+                                                    })}
                                                 </select>
                                             </td>
                                             <td>
                                                 <select
                                                     value={cur_template}
-                                                    onChange={(e)=>this.props.handleSelectTemplate(e.target.value, plot_index)}
+                                                    onChange={e => this.props.handleSelectTemplate(e.target.value, plot_index)}
                                                     className="form-control"
                                                     id="plot-inspector-template-select"
-                                                    >
-                                                    {
-                                                        this.props.templates.sort((a, b)=>{
+                                                >
+                                                    {this.props.templates
+                                                        .sort((a, b) => {
                                                             return a.toLowerCase().localeCompare(b.toLowerCase());
-                                                        }).map((name, index)=>{
-                                                            return <option key={index} value={name}>{name}</option>
                                                         })
-                                                    }
+                                                        .map((name, index) => {
+                                                            return (
+                                                                <option key={index} value={name}>
+                                                                    {name}
+                                                                </option>
+                                                            );
+                                                        })}
                                                 </select>
                                             </td>
                                         </tr>
-                                    )
-                                })
-                            }
+                                    );
+                                })}
                         </tbody>
                     </table>
                 </div>
-                {this.props.show_colormap_editor && 
-                    <ColormapEditor show={this.props.show_colormap_editor} close={this.props.handleCloseColormapEditor}/>
-                }
+                {this.props.show_colormap_editor && (
+                    <ColormapEditor show={this.props.show_colormap_editor} close={this.props.handleCloseColormapEditor} />
+                )}
             </div>
-        )
+        );
     }
 }
 
@@ -222,7 +253,7 @@ PlotInspector.propTypes = {
     show_colormap_editor: PropTypes.bool,
     startTour: PropTypes.func,
     handleOpenExportModal: PropTypes.func,
-}
+    handleOpenCalculator: PropTypes.func
+};
 
 export default PlotInspector;
-

--- a/frontend/src/js/components/PlotInspector/PlotInspectorWrapper.jsx
+++ b/frontend/src/js/components/PlotInspector/PlotInspectorWrapper.jsx
@@ -1,113 +1,121 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import Actions from '../../constants/Actions.js'
-import PubSub from 'pubsub-js'
-import PubSubEvents from './../../constants/PubSubEvents.js'
-import { toast } from 'react-toastify'
-import PlotInspector from './PlotInspector.jsx'
-import ExportModal from '../modals/ExportModal.jsx'
-import './PlotInspector.scss'
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import Actions from "../../constants/Actions.js";
+import PubSub from "pubsub-js";
+import PubSubEvents from "./../../constants/PubSubEvents.js";
+import { toast } from "react-toastify";
+import PlotInspector from "./PlotInspector.jsx";
+import ExportModal from "../modals/ExportModal.jsx";
+import Calculator from "../modals/Calculator/Calculator.jsx";
+import "./PlotInspector.scss";
 
 class PlotInspectorWrapper extends React.Component {
-
-    constructor(props){
-        super(props)
+    constructor(props) {
+        super(props);
         this.state = {
             show_colormap_editor: false,
-            show_export_modal: false,
-        }
-        this.handleSelectVar1 = this.handleSelectVar1.bind(this)
-        this.handleSelectVar2 = this.handleSelectVar2.bind(this)
-        this.handleSelectGMType = this.handleSelectGMType.bind(this)
-        this.handleSelectGM = this.handleSelectGM.bind(this)
-        this.handleSelectTemplate = this.handleSelectTemplate.bind(this)
-        this.handleAddPlot = this.handleAddPlot.bind(this)
-        this.handleDeletePlot = this.handleDeletePlot.bind(this)
-        this.handleClearCell = this.handleClearCell.bind(this)
-        this.handleCloseColormapEditor = this.handleCloseColormapEditor.bind(this)
-        this.handleOpenColormapEditor = this.handleOpenColormapEditor.bind(this)
-        this.handleSavePlot = this.handleSavePlot.bind(this)
-        this.handleOpenExportModal = this.handleOpenExportModal.bind(this)
-        this.handleCloseExportModal = this.handleCloseExportModal.bind(this)
+            show_export_modal: false
+        };
+        this.handleSelectVar1 = this.handleSelectVar1.bind(this);
+        this.handleSelectVar2 = this.handleSelectVar2.bind(this);
+        this.handleSelectGMType = this.handleSelectGMType.bind(this);
+        this.handleSelectGM = this.handleSelectGM.bind(this);
+        this.handleSelectTemplate = this.handleSelectTemplate.bind(this);
+        this.handleAddPlot = this.handleAddPlot.bind(this);
+        this.handleDeletePlot = this.handleDeletePlot.bind(this);
+        this.handleClearCell = this.handleClearCell.bind(this);
+        this.handleCloseColormapEditor = this.handleCloseColormapEditor.bind(this);
+        this.handleOpenColormapEditor = this.handleOpenColormapEditor.bind(this);
+        this.handleSavePlot = this.handleSavePlot.bind(this);
+        this.handleOpenExportModal = this.handleOpenExportModal.bind(this);
+        this.handleCloseExportModal = this.handleCloseExportModal.bind(this);
+        this.handleOpenCalculator = this.handleOpenCalculator.bind(this);
+        this.handleCloseCalculator = this.handleCloseCalculator.bind(this);
     }
 
-    handleSelectVar1(var1, plot_index){
-        const FIRST_VARIABLE = 0
-        this.props.swapVariableInPlot(this.props.cell_row, this.props.cell_col, var1, plot_index, FIRST_VARIABLE)
+    handleSelectVar1(var1, plot_index) {
+        const FIRST_VARIABLE = 0;
+        this.props.swapVariableInPlot(this.props.cell_row, this.props.cell_col, var1, plot_index, FIRST_VARIABLE);
     }
 
-    handleSelectVar2(var2, plot_index){
-        const SECOND_VARIABLE = 1
-        if(var2 === ""){
-            this.props.deleteVariableInPlot(this.props.cell_row, this.props.cell_col, plot_index, SECOND_VARIABLE)
-        }
-        else{
-            this.props.swapVariableInPlot(this.props.cell_row, this.props.cell_col, var2, plot_index, SECOND_VARIABLE)
+    handleSelectVar2(var2, plot_index) {
+        const SECOND_VARIABLE = 1;
+        if (var2 === "") {
+            this.props.deleteVariableInPlot(this.props.cell_row, this.props.cell_col, plot_index, SECOND_VARIABLE);
+        } else {
+            this.props.swapVariableInPlot(this.props.cell_row, this.props.cell_col, var2, plot_index, SECOND_VARIABLE);
         }
     }
 
-    handleSelectGMType(graphic_type, plot_index){
-        let graphics_method = ""
-        if(this.props.all_graphics_methods[graphic_type]["default"]){ // when switching the graphics type, try to set the method to default
-            graphics_method = "default"
-        }
-        else if(Object.keys(this.props.all_graphics_methods[graphic_type]).length > 0){ // if there is no default check that the parent/type exists
-            graphics_method = Object.keys(this.props.all_graphics_methods[graphic_type])[0] // Then set to the first entry 
-        }
+    handleSelectGMType(graphic_type, plot_index) {
+        let graphics_method = "";
+        if (this.props.all_graphics_methods[graphic_type]["default"]) {
+            // when switching the graphics type, try to set the method to default
+            graphics_method = "default";
+        } else if (Object.keys(this.props.all_graphics_methods[graphic_type]).length > 0) {
+            // if there is no default check that the parent/type exists
+            graphics_method = Object.keys(this.props.all_graphics_methods[graphic_type])[0]; // Then set to the first entry
+        } else {
         /* istanbul ignore next */
-        else{
-            throw "Error: Graphics type has no child methods."
+            throw "Error: Graphics type has no child methods.";
         }
-        this.props.swapGraphicsMethodInPlot(this.props.cell_row, this.props.cell_col, graphic_type, graphics_method, plot_index)
+        this.props.swapGraphicsMethodInPlot(this.props.cell_row, this.props.cell_col, graphic_type, graphics_method, plot_index);
     }
 
-    handleSelectGM(graphic_type, graphics_method, plot_index){
-        this.props.swapGraphicsMethodInPlot(this.props.cell_row, this.props.cell_col, graphic_type, graphics_method, plot_index)
+    handleSelectGM(graphic_type, graphics_method, plot_index) {
+        this.props.swapGraphicsMethodInPlot(this.props.cell_row, this.props.cell_col, graphic_type, graphics_method, plot_index);
     }
 
-    handleSelectTemplate(template, plot_index){
-        this.props.swapTemplateInPlot(this.props.cell_row, this.props.cell_col, template, plot_index)
+    handleSelectTemplate(template, plot_index) {
+        this.props.swapTemplateInPlot(this.props.cell_row, this.props.cell_col, template, plot_index);
     }
 
-    handleAddPlot(){
-        this.props.addPlot(null, null, null, null, this.props.cell_row, this.props.cell_col)
+    handleAddPlot() {
+        this.props.addPlot(null, null, null, null, this.props.cell_row, this.props.cell_col);
     }
 
-    handleDeletePlot(plot_index){
-        this.props.deletePlot(this.props.cell_row, this.props.cell_col, plot_index)
+    handleDeletePlot(plot_index) {
+        this.props.deletePlot(this.props.cell_row, this.props.cell_col, plot_index);
     }
 
-    handleClearCell(){
-        if(this.props.cell_selected === "-1_-1_-1"){
-            toast.info("A cell must be selected to clear", {position: toast.POSITION.BOTTOM_CENTER})
-        }
-        else{
-            PubSub.publish(PubSubEvents.clear_canvas)
+    handleClearCell() {
+        if (this.props.cell_selected === "-1_-1_-1") {
+            toast.info("A cell must be selected to clear", { position: toast.POSITION.BOTTOM_CENTER });
+        } else {
+            PubSub.publish(PubSubEvents.clear_canvas);
         }
     }
-    handleOpenColormapEditor(){
-        this.setState({show_colormap_editor: true})
+    handleOpenColormapEditor() {
+        this.setState({ show_colormap_editor: true });
     }
 
-    handleCloseColormapEditor(){
-        this.setState({show_colormap_editor: false})
+    handleCloseColormapEditor() {
+        this.setState({ show_colormap_editor: false });
     }
 
-    handleOpenExportModal(){
-        this.setState({show_export_modal: true})
+    handleOpenExportModal() {
+        this.setState({ show_export_modal: true });
     }
 
-    handleCloseExportModal(){
-        this.setState({show_export_modal: false})
+    handleCloseExportModal() {
+        this.setState({ show_export_modal: false });
     }
 
-    handleSavePlot(){
-        PubSub.publish(PubSubEvents.save_canvas)
+    handleSavePlot() {
+        PubSub.publish(PubSubEvents.save_canvas);
     }
-    
+
+    handleOpenCalculator() {
+        this.setState({ show_calculator: true });
+    }
+
+    handleCloseCalculator() {
+        this.setState({ show_calculator: false });
+    }
+
     render() {
-        return(
+        return (
             <div className="plot-inspector-wrapper">
                 <PlotInspector
                     {...this.props}
@@ -126,17 +134,12 @@ class PlotInspectorWrapper extends React.Component {
                     handleCloseColormapEditor={this.handleCloseColormapEditor}
                     handleClearCell={this.handleClearCell}
                     handleOpenExportModal={this.handleOpenExportModal}
+                    handleOpenCalculator={this.handleOpenCalculator}
                 />
-                {
-                    this.state.show_export_modal &&
-                    <ExportModal
-                        show={this.state.show_export_modal}
-                        close={this.handleCloseExportModal}
-                    />
-                }
+                {this.state.show_export_modal && <ExportModal show={this.state.show_export_modal} close={this.handleCloseExportModal} />}
+                {this.state.show_calculator && <Calculator show={this.state.show_calculator} close={this.handleCloseCalculator} />}
             </div>
-            
-        )
+        );
     }
 }
 
@@ -154,18 +157,20 @@ PlotInspectorWrapper.propTypes = {
     deleteVariableInPlot: PropTypes.func,
     addPlot: PropTypes.func,
     deletePlot: PropTypes.func,
-    cell_selected: PropTypes.string,
-}
+    cell_selected: PropTypes.string
+};
 
-const mapStateToProps = (state) => {
-    let cell_id_string = state.present.sheets_model.selected_cell_id // format of `sheet_row_col`. Ex: "0_0_0"
-    let sheet_row_col = cell_id_string.split("_").map(function (str_val) { return Number(str_val) })
-    let sheet = sheet_row_col[0]
-    let row = sheet_row_col[1]
-    let col = sheet_row_col[2]
-    let plots = []
-    if(row != -1 && col != -1 && sheet != -1 && state.present.sheets_model.sheets && state.present.sheets_model.sheets[sheet]){
-        plots = state.present.sheets_model.sheets[sheet].cells[row][col].plots
+const mapStateToProps = state => {
+    let cell_id_string = state.present.sheets_model.selected_cell_id; // format of `sheet_row_col`. Ex: "0_0_0"
+    let sheet_row_col = cell_id_string.split("_").map(function(str_val) {
+        return Number(str_val);
+    });
+    let sheet = sheet_row_col[0];
+    let row = sheet_row_col[1];
+    let col = sheet_row_col[2];
+    let plots = [];
+    if (row != -1 && col != -1 && sheet != -1 && state.present.sheets_model.sheets && state.present.sheets_model.sheets[sheet]) {
+        plots = state.present.sheets_model.sheets[sheet].cells[row][col].plots;
     }
     return {
         cell_selected: cell_id_string,
@@ -175,35 +180,37 @@ const mapStateToProps = (state) => {
         all_graphics_methods: state.present.graphics_methods,
         variables: state.present.variables ? Object.keys(state.present.variables) : [],
         graphics_method_types: state.present.graphics_methods ? Object.keys(state.present.graphics_methods) : [],
-        templates: state.present.templates ? state.present.templates : [],
-    }
-}
+        templates: state.present.templates ? state.present.templates : []
+    };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
     return {
-        addPlot: function(variable=null, graphics_method_parent=null, graphics_method=null, template=null, row, col) {
-            dispatch(Actions.addPlot(variable, graphics_method_parent, graphics_method, template, row, col))
+        addPlot: function(variable = null, graphics_method_parent = null, graphics_method = null, template = null, row, col) {
+            dispatch(Actions.addPlot(variable, graphics_method_parent, graphics_method, template, row, col));
         },
         deletePlot: function(row, col, index) {
-            dispatch(Actions.deletePlot(row, col, index))
+            dispatch(Actions.deletePlot(row, col, index));
         },
-        swapVariableInPlot: function(row, col, value, index, var_being_changed=0) {
-            dispatch(Actions.swapVariableInPlot(value, row, col, index, var_being_changed))
+        swapVariableInPlot: function(row, col, value, index, var_being_changed = 0) {
+            dispatch(Actions.swapVariableInPlot(value, row, col, index, var_being_changed));
         },
         swapGraphicsMethodInPlot: function(row, col, graphics_method_parent, graphics_method, index) {
-            dispatch(Actions.swapGraphicsMethodInPlot(graphics_method_parent, graphics_method, row, col, index))
+            dispatch(Actions.swapGraphicsMethodInPlot(graphics_method_parent, graphics_method, row, col, index));
         },
         swapTemplateInPlot: function(row, col, value, index) {
-            dispatch(Actions.swapTemplateInPlot(value, row, col, index))
+            dispatch(Actions.swapTemplateInPlot(value, row, col, index));
         },
-        deleteVariableInPlot: function(row, col, index, var_being_deleted){
-            dispatch(Actions.deleteVariableInPlot(row, col, index, var_being_deleted))
+        deleteVariableInPlot: function(row, col, index, var_being_deleted) {
+            dispatch(Actions.deleteVariableInPlot(row, col, index, var_being_deleted));
         }
-    }
-}
+    };
+};
 
-export default connect(mapStateToProps, mapDispatchToProps)(PlotInspectorWrapper);
-export { PlotInspectorWrapper as PurePlotInspectorWrapper }
-export { mapDispatchToProps } // for unit testing
-export { mapStateToProps }    // for unit testing
-
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(PlotInspectorWrapper);
+export { PlotInspectorWrapper as PurePlotInspectorWrapper };
+export { mapDispatchToProps }; // for unit testing
+export { mapStateToProps }; // for unit testing

--- a/frontend/src/js/components/modals/CachedFiles/DimensionSlider/DimensionSlider.jsx
+++ b/frontend/src/js/components/modals/CachedFiles/DimensionSlider/DimensionSlider.jsx
@@ -1,69 +1,69 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import Slider from 'bootstrap-slider'
-import moment from 'moment'
-import { FormGroup, FormControl, ControlLabel } from 'react-bootstrap'
-import _ from 'lodash'
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import Slider from "bootstrap-slider";
+import moment from "moment";
+import { FormGroup, FormControl, ControlLabel } from "react-bootstrap";
+import _ from "lodash";
 
-import './DimensionSlider.scss'
+import "./DimensionSlider.scss";
 
-import 'bootstrap-slider/dist/css/bootstrap-slider.min.css'
+import "bootstrap-slider/dist/css/bootstrap-slider.min.css";
 
 class DimensionSlider extends Component {
     constructor(props) {
-        super(props)
-        this.slider = null
-        let format = null
-        let possible_values = props.data
-        this.formatter = function (data) {
+        super(props);
+        this.slider = null;
+        let format = null;
+        let possible_values = props.data;
+        this.formatter = function(data) {
             if (data.toFixed) {
                 return data.toFixed(5);
             }
-            return data
-        }
-        if (_.includes(props.units, 'since')) {
-            let [span, , startTime] = props.units.split(' ');
+            return data;
+        };
+        if (_.includes(props.units, "since")) {
+            let [span, , startTime] = props.units.split(" ");
             switch (span) {
-                case 'years':
-                    format = 'YYYY'
-                    break
-                case 'months':
-                    format = 'YYYY-MM'
-                    break
-                case 'days':
-                    format = 'YYYY-MM-DD'
-                    break
-                case 'hours':
-                case 'minutes':
-                    format = 'YYYY-MM-DD HH:mm'
-                    break
-                case 'seconds':
-                    format = 'YYYY-MM-DD HH:mm:ss'
-                    break
+                case "years":
+                    format = "YYYY";
+                    break;
+                case "months":
+                    format = "YYYY-MM";
+                    break;
+                case "days":
+                    format = "YYYY-MM-DD";
+                    break;
+                case "hours":
+                case "minutes":
+                    format = "YYYY-MM-DD HH:mm";
+                    break;
+                case "seconds":
+                    format = "YYYY-MM-DD HH:mm:ss";
+                    break;
             }
-            this.formatter = function (data) {
-                return moment(startTime, 'YYYY-MM-DD').add(data, span).format(format)
-            }
+            this.formatter = function(data) {
+                return moment(startTime, "YYYY-MM-DD")
+                    .add(data, span)
+                    .format(format);
+            };
         }
-        if(props.modulo){
-            let new_possible_values = []
-            let step = Math.abs(props.data[0] - props.data[1])
-            for(let i = -props.modulo; i <= props.modulo; i += step){
-                new_possible_values.push(i)
+        if (props.modulo) {
+            let new_possible_values = [];
+            let step = Math.abs(props.data[0] - props.data[1]);
+            for (let i = -props.modulo; i <= props.modulo; i += step) {
+                new_possible_values.push(i);
             }
-            possible_values = new_possible_values
+            possible_values = new_possible_values;
         }
-        this.singleValue = props.data.length == 1
-        let low_value = possible_values.indexOf(this.props.low_value)
-        let high_value = possible_values.indexOf(this.props.high_value)
+        this.singleValue = props.data.length == 1;
+        let low_value = possible_values.indexOf(this.props.low_value);
+        let high_value = possible_values.indexOf(this.props.high_value);
         this.state = {
             min: 0,
             max: possible_values.length - 1,
             value: [
-                possible_values[(low_value !== -1 ? low_value : possible_values.indexOf(this.props.data[0]))],
-                possible_values[(high_value !== -1 ? 
-                    high_value : possible_values.indexOf(this.props.data[this.props.data.length - 1])
-                )],
+                possible_values[low_value !== -1 ? low_value : possible_values.indexOf(this.props.data[0])],
+                possible_values[high_value !== -1 ? high_value : possible_values.indexOf(this.props.data[this.props.data.length - 1])]
             ],
             stride: 1,
             data: possible_values
@@ -73,17 +73,17 @@ class DimensionSlider extends Component {
     componentDidMount() {
         // props.data represents the original data array of values
         // state.data is the array of data created to allow greater ranges than the data contains
-        // This is based of the modulo provided to us. 
-        // Example: props.data = [-180, ..., 175] 
+        // This is based of the modulo provided to us.
+        // Example: props.data = [-180, ..., 175]
         //          state.data = [-360, ..., 360] (modulo: 360)
 
-        let low_value = this.state.data.indexOf(this.props.low_value)
-        if(low_value === -1){
-            low_value = this.state.data.indexOf(this.props.data[0])
+        let low_value = this.state.data.indexOf(this.props.low_value);
+        if (low_value === -1) {
+            low_value = this.state.data.indexOf(this.props.data[0]);
         }
-        let high_value = this.state.data.indexOf(this.props.high_value)
-        if(high_value === -1){
-            high_value = this.state.data.indexOf(this.props.data[this.props.data.length -1])
+        let high_value = this.state.data.indexOf(this.props.high_value);
+        if (high_value === -1) {
+            high_value = this.state.data.indexOf(this.props.data[this.props.data.length - 1]);
         }
 
         if (this.singleValue) {
@@ -96,18 +96,18 @@ class DimensionSlider extends Component {
             step: 1,
             value: [
                 low_value !== -1 ? low_value : this.state.min,
-                high_value !== -1 ? high_value : this.state.max,
+                high_value !== -1 ? high_value : this.state.max
                 // if the passed in prop value is invalid or not present we get -1 and use the min/max value instead
             ],
             range: true,
             across: true,
-            tooltip: 'hide',
+            tooltip: "hide",
             formatter: this.formatter
-        }).on('change', (arg) => {
-            var sliderValues = arg.newValue
-            var value = [this.state.data[sliderValues[0]], this.state.data[sliderValues[1]]]
-            this.setState({ value })
-        })
+        }).on("change", arg => {
+            var sliderValues = arg.newValue;
+            var value = [this.state.data[sliderValues[0]], this.state.data[sliderValues[1]]];
+            this.setState({ value });
+        });
     }
 
     componentWillUnmount() {
@@ -140,16 +140,23 @@ class DimensionSlider extends Component {
     render() {
         return (
             <div className="dimension-slider">
-                {!this.singleValue &&
+                {!this.singleValue && (
                     <div className="form-inline">
                         <FormControl
                             id="dimension-slider-select-lower"
                             bsSize="sm"
                             componentClass="select"
-                            onChange={(e) => {this.setState({ value: [parseInt(e.target.value), this.state.value[1]] })}}
-                            value={this.state.value[0]}>
-                            {this.state.data.map((data) => {
-                                return <option key={data} value={data}>{this.formatter(data)}</option>;
+                            onChange={e => {
+                                this.setState({ value: [parseInt(e.target.value), this.state.value[1]] });
+                            }}
+                            value={this.state.value[0]}
+                        >
+                            {this.state.data.map(data => {
+                                return (
+                                    <option key={data} value={data}>
+                                        {this.formatter(data)}
+                                    </option>
+                                );
                             })}
                         </FormControl>
                         &nbsp;:&nbsp;
@@ -157,37 +164,40 @@ class DimensionSlider extends Component {
                             id="dimension-slider-select-upper"
                             bsSize="sm"
                             componentClass="select"
-                            onChange={(e) => this.setState({ value: [this.state.value[0], parseInt(e.target.value)] })}
-                            value={this.state.value[1]}>
-                            {this.state.data.map((data) => {
-                                return <option key={data} value={data}>{this.formatter(data)}</option>;
+                            onChange={e => this.setState({ value: [this.state.value[0], parseInt(e.target.value)] })}
+                            value={this.state.value[1]}
+                        >
+                            {this.state.data.map(data => {
+                                return (
+                                    <option key={data} value={data}>
+                                        {this.formatter(data)}
+                                    </option>
+                                );
                             })}
                         </FormControl>
-                        <FormGroup
-                            className="stride"
-                            bsSize="sm">
+                        <FormGroup className="stride" bsSize="sm">
                             <ControlLabel>stride:&nbsp;</ControlLabel>
                             <FormControl
                                 type="number"
                                 min="1"
                                 step="1"
                                 value={this.state.stride}
-                                onChange={(e) => this.setState({ stride: parseInt(e.target.value) })} />
+                                onChange={e => this.setState({ stride: parseInt(e.target.value) })}
+                            />
                         </FormGroup>
-                        { !this.props.isTime &&
-                            <small className="units">
-                                ({this.props.units})
-                            </small>
-                        }
-                        <input ref={input => this.input = input} />
+                        {!this.props.isTime && <small className="units">({this.props.units})</small>}
+                        <input ref={input => (this.input = input)} />
                     </div>
-                }
-                {this.singleValue &&
+                )}
+                {this.singleValue && (
                     <div>
-                        <span>({this.props.data.length}) {this.formatter(this.state.value[0])}</span>
-                    </div>}
+                        <span>
+                            ({this.props.data.length}) {this.formatter(this.state.value[0])}
+                        </span>
+                    </div>
+                )}
             </div>
-        )
+        );
     }
 }
 
@@ -198,7 +208,7 @@ DimensionSlider.propTypes = {
     onChange: PropTypes.func,
     units: PropTypes.string,
     modulo: PropTypes.number,
-    isTime: PropTypes.bool,
-}
+    isTime: PropTypes.bool
+};
 
 export default DimensionSlider;

--- a/frontend/src/js/components/modals/CachedFiles/Tabs/FileTab.jsx
+++ b/frontend/src/js/components/modals/CachedFiles/Tabs/FileTab.jsx
@@ -1,49 +1,52 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import { Modal, Button, Row, Col, Glyphicon, FormGroup, FormControl, ControlLabel, InputGroup } from 'react-bootstrap'
-import _ from 'lodash'
-import Dialog from 'react-bootstrap-dialog'
-import { DropTarget, DragSource } from 'react-dnd'
-import { findDOMNode } from 'react-dom'
-import { toast } from 'react-toastify'
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { Modal, Button, Row, Col, Glyphicon, FormGroup, FormControl, ControlLabel, InputGroup } from "react-bootstrap";
+import _ from "lodash";
+import Dialog from "react-bootstrap-dialog";
+import { DropTarget, DragSource } from "react-dnd";
+import { findDOMNode } from "react-dom";
+import { toast } from "react-toastify";
 
-import Actions from '../../../../constants/Actions.js'
-import DimensionSlider from './../DimensionSlider/DimensionSlider.jsx'
-import FileExplorer from '../../FileExplorer/FileExplorer.jsx'
-import DragAndDropTypes from '../../../../constants/DragAndDropTypes.js'
-import FileInfoModal from '../../FileInfoModal/FileInfoModal.jsx'
+import Actions from "../../../../constants/Actions.js";
+import DimensionSlider from "./../DimensionSlider/DimensionSlider.jsx";
+import FileExplorer from "../../FileExplorer/FileExplorer.jsx";
+import DragAndDropTypes from "../../../../constants/DragAndDropTypes.js";
+import FileInfoModal from "../../FileInfoModal/FileInfoModal.jsx";
 
-import '../CachedFiles.scss'
-import AxisTransform from '../AxisTransform.jsx'
+import "../CachedFiles.scss";
+import AxisTransform from "../AxisTransform.jsx";
 
 function cleanPath(path) {
-    return `/${path.split('/').filter(segment => segment).join('/')}`;
+    return `/${path
+        .split("/")
+        .filter(segment => segment)
+        .join("/")}`;
 }
 
-function getDefaultVariable(names){
+function getDefaultVariable(names) {
     // The select box for variables needs to attempt to choose a default variable.
     // This function attempts to return an index for an entry in the array that is unlikely to be a bounds variable.
-    // If no suitable candidate is found, will return 0 
+    // If no suitable candidate is found, will return 0
 
-    const substrings = ["bound", "bnds", "lat", "lon", "axis"] // substrings that indicate a bounds variable
-    const sorted_names = names.sort(function (a, b) {
+    const substrings = ["bound", "bnds", "lat", "lon", "axis"]; // substrings that indicate a bounds variable
+    const sorted_names = names.sort(function(a, b) {
         return a.toLowerCase().localeCompare(b.toLowerCase());
-    })
-    for(let name of sorted_names){
-        const is_variable = substrings.reduce((prev_val, substring)=>{
-            return prev_val && !name.includes(substring) // assume name is a variable until detected otherwise
-        }, true)
+    });
+    for (let name of sorted_names) {
+        const is_variable = substrings.reduce((prev_val, substring) => {
+            return prev_val && !name.includes(substring); // assume name is a variable until detected otherwise
+        }, true);
 
-        if(is_variable){
-            return name // return the name of the first variable that doesnt represent a bound
-        } 
+        if (is_variable) {
+            return name; // return the name of the first variable that doesnt represent a bound
+        }
     }
-    return sorted_names[0] // return the first name if none matched
+    return sorted_names[0]; // return the first name if none matched
 }
 
-const HISTORY_KEY = "variable_history_files"
-const BOOKMARK_KEY = "variable_bookmark_files"
+const HISTORY_KEY = "variable_history_files";
+const BOOKMARK_KEY = "variable_bookmark_files";
 
 class FileTab extends Component {
     constructor(props) {
@@ -51,67 +54,63 @@ class FileTab extends Component {
         let history_files;
         let bookmark_files;
         try {
-             history_files = JSON.parse(window.localStorage.getItem(HISTORY_KEY))
-             if (!Array.isArray(history_files)){
-                history_files = []
+            history_files = JSON.parse(window.localStorage.getItem(HISTORY_KEY));
+            if (!Array.isArray(history_files)) {
+                history_files = [];
             }
+        } catch (e) {
+            history_files = [];
         }
-        catch(e){
-            history_files = []
-        }
-        try{
-            bookmark_files = JSON.parse(window.localStorage.getItem(BOOKMARK_KEY))
-            if (!Array.isArray(bookmark_files)){
-                bookmark_files = []   
+        try {
+            bookmark_files = JSON.parse(window.localStorage.getItem(BOOKMARK_KEY));
+            if (!Array.isArray(bookmark_files)) {
+                bookmark_files = [];
             }
-        }
-        catch(e){
-            bookmark_files = []
+        } catch (e) {
+            bookmark_files = [];
         }
         this.state = {
             showFileExplorer: false,
             showRedefineVariableModal: false,
-            selectedFile: '',
+            selectedFile: "",
             historyFiles: history_files,
             bookmarkFiles: bookmark_files,
             showBookmarkZone: false,
             variablesAxes: null,
             axisTransforms: {},
             selectedVariable: null,
-            selectedVariableName: '',
-            redefinedVariableName: '',
-            temporaryRedefinedVariableName: '',
+            selectedVariableName: "",
+            redefinedVariableName: "",
+            temporaryRedefinedVariableName: "",
             dimension: null,
             recent_path: "",
-            showFileInfoModal: false,
-
-        }
-        this.handleCloseFileInfoModal = this.handleCloseFileInfoModal.bind(this)
-        this.handleAxisTransform = this.handleAxisTransform.bind(this)
+            showFileInfoModal: false
+        };
+        this.handleCloseFileInfoModal = this.handleCloseFileInfoModal.bind(this);
+        this.handleAxisTransform = this.handleAxisTransform.bind(this);
     }
 
     get selectedFilePath() {
-        return !this.state.selectedFile ? '' : cleanPath(this.state.selectedFile.path + '/' + this.state.selectedFile.name);
+        return !this.state.selectedFile ? "" : cleanPath(this.state.selectedFile.path + "/" + this.state.selectedFile.name);
     }
 
     get variableName() {
         if (this.state.redefinedVariableName) {
             return this.state.redefinedVariableName;
         }
-        return !this.state.selectedVariableName ? '' : this.state.selectedVariableName;
+        return !this.state.selectedVariableName ? "" : this.state.selectedVariableName;
     }
 
     componentDidUpdate(prevProps, prevState) {
         if (this.state.selectedVariableName !== prevState.selectedVariableName || (this.state.selectedVariableName && !this.state.selectedVariable)) {
             let selectedVariable, dimension;
             if (this.state.variablesAxes[0][this.state.selectedVariableName]) {
-                // it's a variablevar 
+                // it's a variablevar
                 selectedVariable = this.state.variablesAxes[0][this.state.selectedVariableName];
-                dimension = selectedVariable.axisList.map((axisName) => {
+                dimension = selectedVariable.axisList.map(axisName => {
                     return { axisName };
-                })
-            }
-            else {
+                });
+            } else {
                 // it's a axis
                 selectedVariable = this.state.variablesAxes[1][this.state.selectedVariableName];
                 dimension = { axisName: this.state.selectedVariableName };
@@ -137,37 +136,33 @@ class FileTab extends Component {
             dimension: this.state.dimension,
             transforms: this.state.axisTransforms
         };
-        
+
         this.props.loadVariables([var_obj]);
-        toast.success(`Successfully Loaded ${variable}`, { position: toast.POSITION.BOTTOM_CENTER})
-        this.setState({ redefinedVariableName: '' });
+        toast.success(`Successfully Loaded ${variable}`, { position: toast.POSITION.BOTTOM_CENTER });
+        this.setState({ redefinedVariableName: "" });
     }
 
     load() {
         return this.variableNameExists()
-            .then((result) => {
+            .then(result => {
                 if (result) {
                     return new Promise((resolve, reject) => {
                         this.refs.dialog.show({
-                            title: 'Variable exists',
+                            title: "Variable exists",
                             body: `The variable name ${this.variableName} already exists, rename or overwrite existing variable`,
-                            actions: [
-                                Dialog.OKAction(() => resolve()),
-                                Dialog.CancelAction(() => reject())
-                            ]
-                        })
-                    })
-                        .then(() => this.redefineVariableName());
+                            actions: [Dialog.OKAction(() => resolve()), Dialog.CancelAction(() => reject())]
+                        });
+                    }).then(() => this.redefineVariableName());
                 }
             })
             .then(() => {
-                return this.loadVariable()
+                return this.loadVariable();
             })
-            .catch((e) =>{
-                if(e){
-                    console.warn(e)
+            .catch(e => {
+                if (e) {
+                    console.warn(e);
                 }
-            })
+            });
     }
 
     /* istanbul ignore next */
@@ -176,10 +171,9 @@ class FileTab extends Component {
     }
 
     loadAs() {
-        this.redefineVariableName()
-            .then(() => {
-                this.loadVariable();
-            })
+        this.redefineVariableName().then(() => {
+            this.loadVariable();
+        });
     }
 
     /* istanbul ignore next */
@@ -189,12 +183,14 @@ class FileTab extends Component {
 
     redefineVariableName() {
         return new Promise((resolve, reject) => {
-            this.doneRedefineVariable = () => { resolve() };
+            this.doneRedefineVariable = () => {
+                resolve();
+            };
             this.setState({
                 showRedefineVariableModal: true,
                 temporaryRedefinedVariableName: this.variableName
             });
-        })
+        });
     }
 
     /* istanbul ignore next */
@@ -203,140 +199,142 @@ class FileTab extends Component {
     }
 
     handleFileSelected(file) {
-        var path = cleanPath(file.path + '/' + file.name);
-        var self = this
-        let recent_path = cleanPath(file.path)
-        this.props.setRecentFolderOpened(recent_path) 
+        var path = cleanPath(file.path + "/" + file.name);
+        var self = this;
+        let recent_path = cleanPath(file.path);
+        this.props.setRecentFolderOpened(recent_path);
         return new Promise((resolve, reject) => {
-            try{
+            try {
                 resolve(
-                    vcs.variables(path).then(
-                        (variablesAxes) => { // success
-                            var historyFiles = [file, ...self.state.historyFiles.filter(historyFile => {
-                                return historyFile.path !== file.path || historyFile.name !== file.name
-                            })]
-                            window.localStorage.setItem(HISTORY_KEY, JSON.stringify(historyFiles))
-                            const selected_variable = getDefaultVariable(Object.keys(variablesAxes[0]))
+                    vcs.allvariables(path).then(
+                        variablesAxes => {
+                            // success
+                            var historyFiles = [
+                                file,
+                                ...self.state.historyFiles.filter(historyFile => {
+                                    return historyFile.path !== file.path || historyFile.name !== file.name;
+                                })
+                            ];
+                            window.localStorage.setItem(HISTORY_KEY, JSON.stringify(historyFiles));
+                            const selected_variable = getDefaultVariable(Object.keys(variablesAxes[0]));
                             self.setState({
                                 variablesAxes,
                                 selectedFile: file,
                                 historyFiles: historyFiles,
-                                selectedVariableName:  selected_variable,
+                                selectedVariableName: selected_variable,
                                 selectedVariable: null,
                                 showFileExplorer: false
-                            })
+                            });
                         },
-                        (error) => { // error
-                            if(!(error instanceof ReferenceError)){
-                                console.error(error)
-                                switch(error.code){
+                        error => {
+                            // error
+                            if (!(error instanceof ReferenceError)) {
+                                console.error(error);
+                                switch (error.code) {
                                     case -32001: // CDMSError(u'Cannot open file /example/path/to/a/file.nc (No error)',)
                                         toast.error("CDMS can not open this file, please select another", {
                                             position: toast.POSITION.BOTTOM_CENTER
                                         });
-                                        return
+                                        return;
                                     case -32099:
                                         toast.error("VCS connection is closed. Try restarting vCDAT.", {
                                             position: toast.POSITION.BOTTOM_CENTER
                                         });
-                                        return    
+                                        return;
                                     default:
                                         toast.error("Failed to load file. Please try another one.", {
                                             position: toast.POSITION.BOTTOM_CENTER
-                                        });   
-                                        return
+                                        });
+                                        return;
                                 }
                             }
                         }
                     )
-                )
-            }
-            catch(e){
-                if(e instanceof ReferenceError){
-                    toast.error("VCS is not loaded. Try restarting vCDAT", { position: toast.POSITION.BOTTOM_CENTER })
+                );
+            } catch (e) {
+                if (e instanceof ReferenceError) {
+                    toast.error("VCS is not loaded. Try restarting vCDAT", { position: toast.POSITION.BOTTOM_CENTER });
                 }
-                console.warn(e)
-                reject(e)
+                console.warn(e);
+                reject(e);
             }
-        })
+        });
     }
 
     handleDimensionValueChange(values, axisName = undefined) {
         if (axisName) {
-            let new_dimension = this.state.dimension.slice()
+            let new_dimension = this.state.dimension.slice();
             new_dimension.find(dimension => dimension.axisName === axisName).values = values;
-            this.setState({dimension: new_dimension})
-        }
-        else {
-            let new_dimension = this.state.dimension
+            this.setState({ dimension: new_dimension });
+        } else {
+            let new_dimension = this.state.dimension;
             new_dimension.values = values;
-            this.setState({dimension: new_dimension})
+            this.setState({ dimension: new_dimension });
         }
     }
 
-    handleDragStart(event, file, option){
-        let data = _.assign({}, file)
-        event.dataTransfer.setData('text', JSON.stringify(data)); // datatype must be text/plain due to chrome bug
-        this.setState({showBookmarkZone: true})
+    handleDragStart(event, file, option) {
+        let data = _.assign({}, file);
+        event.dataTransfer.setData("text", JSON.stringify(data)); // datatype must be text/plain due to chrome bug
+        this.setState({ showBookmarkZone: true });
     }
 
     /* istanbul ignore next */
-    handleDragOver(event){
-        event.preventDefault()
-        event.stopPropagation() // Stupid drag and drop api issue
+    handleDragOver(event) {
+        event.preventDefault();
+        event.stopPropagation(); // Stupid drag and drop api issue
     }
 
-    handleDrop(event){
+    handleDrop(event) {
         try {
-            let file = JSON.parse(event.dataTransfer.getData('text'));
-            let bookmarks = _.cloneDeep(this.state.bookmarkFiles)
-            for(let bookmark of bookmarks){
-                if( bookmark.name === file.name && cleanPath(bookmark.path) === cleanPath(file.path) ){
-                    return // the file is already bookmarked, don't add it again
+            let file = JSON.parse(event.dataTransfer.getData("text"));
+            let bookmarks = _.cloneDeep(this.state.bookmarkFiles);
+            for (let bookmark of bookmarks) {
+                if (bookmark.name === file.name && cleanPath(bookmark.path) === cleanPath(file.path)) {
+                    return; // the file is already bookmarked, don't add it again
                 }
             }
-            bookmarks.push(file)
-            window.localStorage.setItem(BOOKMARK_KEY, JSON.stringify(bookmarks))
-            this.setState({bookmarkFiles: bookmarks})
+            bookmarks.push(file);
+            window.localStorage.setItem(BOOKMARK_KEY, JSON.stringify(bookmarks));
+            this.setState({ bookmarkFiles: bookmarks });
         } catch (e) {
-            console.error(e)
+            console.error(e);
             return;
         }
     }
 
-    handleDragEnd(event, option){
-        this.setState({showBookmarkZone: false})
+    handleDragEnd(event, option) {
+        this.setState({ showBookmarkZone: false });
     }
 
-    handleDeleteBookmark(index){
-        if(this.state.bookmarkFiles.length > index){
-            let bookmarks = _.cloneDeep(this.state.bookmarkFiles)
-            bookmarks.splice(index, 1)
-            window.localStorage.setItem(BOOKMARK_KEY, JSON.stringify(bookmarks))
-            this.setState({bookmarkFiles: bookmarks})
-        }
+    handleDeleteBookmark(index) {
+        if (this.state.bookmarkFiles.length > index) {
+            let bookmarks = _.cloneDeep(this.state.bookmarkFiles);
+            bookmarks.splice(index, 1);
+            window.localStorage.setItem(BOOKMARK_KEY, JSON.stringify(bookmarks));
+            this.setState({ bookmarkFiles: bookmarks });
+        } else {
         /* istanbul ignore next */
-        else{
-            console.warn("Bookmark index not in range.")
+            console.warn("Bookmark index not in range.");
         }
     }
 
-    handleCloseFileInfoModal(){
-        this.setState({showFileInfoModal: false})
+    handleCloseFileInfoModal() {
+        this.setState({ showFileInfoModal: false });
     }
 
-    handleAxisTransform(axis_name, transform){
-        let new_transforms = _.cloneDeep(this.state.axisTransforms)
-        new_transforms[axis_name] = transform
+    handleAxisTransform(axis_name, transform) {
+        let new_transforms = _.cloneDeep(this.state.axisTransforms);
+        new_transforms[axis_name] = transform;
         this.setState({
             axisTransforms: new_transforms
-        })
+        });
     }
 
     render() {
-        let selected_file_path = ""
-        if(this.state.selectedFile){
-            selected_file_path = cleanPath(this.state.selectedFile.path) + '/' + this.state.selectedFile.name
+        let selected_file_path = "";
+        if (this.state.selectedFile) {
+            selected_file_path = cleanPath(this.state.selectedFile.path) + "/" + this.state.selectedFile.name;
         }
         return (
             <div>
@@ -355,16 +353,15 @@ class FileTab extends Component {
                                 <InputGroup bsSize="small">
                                     <FormControl className="full-width file-path" type="text" value={this.selectedFilePath} />
                                     <InputGroup.Button>
-                                        <Button 
-                                            bsStyle="primary"
-                                            onClick={
-                                                () => this.setState({ showFileExplorer: true })}><Glyphicon glyph="file" />
+                                        <Button bsStyle="primary" onClick={() => this.setState({ showFileExplorer: true })}>
+                                            <Glyphicon glyph="file" />
                                         </Button>
                                         <Button
                                             bsStyle="default"
                                             disabled={!this.state.selectedFile}
-                                            onClick={
-                                                () => this.setState({ showFileInfoModal: true })}><Glyphicon glyph="info-sign" />
+                                            onClick={() => this.setState({ showFileInfoModal: true })}
+                                        >
+                                            <Glyphicon glyph="info-sign" />
                                         </Button>
                                     </InputGroup.Button>
                                 </InputGroup>
@@ -378,8 +375,9 @@ class FileTab extends Component {
                                 <FormControl
                                     className="input-sm full-width"
                                     componentClass="select"
-                                    onChange={(e) => this.setState({ selectedVariableName: e.target.value })}
-                                    value={this.state.selectedVariableName}>
+                                    onChange={e => this.setState({ selectedVariableName: e.target.value })}
+                                    value={this.state.selectedVariableName}
+                                >
                                     {this._formatvariablesAxes()}
                                 </FormControl>
                             </Col>
@@ -392,57 +390,73 @@ class FileTab extends Component {
                                 <FormControl className="history" componentClass="div">
                                     {this.state.historyFiles.map((file, i) => {
                                         return (
-                                            <div 
+                                            <div
                                                 className="file"
                                                 key={i}
                                                 draggable="true"
-                                                onDragStart={(e) => {this.handleDragStart(e, file)}}
-                                                onDragEnd={(e) => {this.handleDragEnd(e)}}
-                                                onClick={(e) => this.handleFileSelected(file)}>
-                                                {cleanPath(file.path + '/' + file.name)}
+                                                onDragStart={e => {
+                                                    this.handleDragStart(e, file);
+                                                }}
+                                                onDragEnd={e => {
+                                                    this.handleDragEnd(e);
+                                                }}
+                                                onClick={e => this.handleFileSelected(file)}
+                                            >
+                                                {cleanPath(file.path + "/" + file.name)}
                                             </div>
-                                        )
+                                        );
                                     })}
                                 </FormControl>
                             </Col>
                         </Row>
                         <Row>
                             <Col className="text-right" sm={2}>
-                                Bookmarks: 
+                                Bookmarks:
                             </Col>
                             <Col sm={9}>
-                                <FormControl 
+                                <FormControl
                                     className="bookmarks"
                                     componentClass="div"
-                                    style={{backgroundColor: this.state.showBookmarkZone ? "#d1ecf1" : "#fff"}}
-                                    onDragOver={(e) => {this.handleDragOver(e)}}
-                                    onDrop={(e) => {this.handleDrop(e)}}
-                                    >
+                                    style={{ backgroundColor: this.state.showBookmarkZone ? "#d1ecf1" : "#fff" }}
+                                    onDragOver={e => {
+                                        this.handleDragOver(e);
+                                    }}
+                                    onDrop={e => {
+                                        this.handleDrop(e);
+                                    }}
+                                >
                                     {this.state.bookmarkFiles.map((file, i) => {
-                                        return(
+                                        return (
                                             <div className="bookmark" key={i}>
                                                 <div
                                                     className="file"
                                                     draggable="true"
-                                                    onDragStart={(e) => {this.handleDragStart(e, file)}}
-                                                    onDragEnd={(e) => {this.handleDragEnd(e)}}
-                                                    onClick={(e) => this.handleFileSelected(file)}>
-                                                    {cleanPath(file.path + '/' + file.name)}
+                                                    onDragStart={e => {
+                                                        this.handleDragStart(e, file);
+                                                    }}
+                                                    onDragEnd={e => {
+                                                        this.handleDragEnd(e);
+                                                    }}
+                                                    onClick={e => this.handleFileSelected(file)}
+                                                >
+                                                    {cleanPath(file.path + "/" + file.name)}
                                                 </div>
                                                 <button
                                                     className="btn btn-danger btn-xs delete-bookmark-button"
-                                                    onClick={()=>{this.handleDeleteBookmark(i)}}
+                                                    onClick={() => {
+                                                        this.handleDeleteBookmark(i);
+                                                    }}
                                                 >
                                                     <Glyphicon glyph="trash" />
                                                 </button>
                                             </div>
-                                        )
+                                        );
                                     })}
                                 </FormControl>
                             </Col>
                         </Row>
                     </div>
-                    {this.state.selectedVariable &&
+                    {this.state.selectedVariable && (
                         <div className="dimensions">
                             <Row>
                                 <Col className="text-right" sm={2}>
@@ -451,7 +465,8 @@ class FileTab extends Component {
                             </Row>
                             {/* If is a variable */}
                             {/* Then we likely have many axes. They need to be reorderable so use the DnDContainer */}
-                            {this.state.dimension && Array.isArray(this.state.dimension) &&
+                            {this.state.dimension &&
+                                Array.isArray(this.state.dimension) &&
                                 this.state.dimension.map(dimension => dimension.axisName).map((axisName, i) => {
                                     let axis = this.state.variablesAxes[1][axisName];
                                     return (
@@ -460,39 +475,60 @@ class FileTab extends Component {
                                                 index={i}
                                                 axis={axis}
                                                 axisName={axisName}
-                                                handleDimensionValueChange={(values) => this.handleDimensionValueChange(values, axisName)}
+                                                handleDimensionValueChange={values => this.handleDimensionValueChange(values, axisName)}
                                                 moveDimension={(dragIndex, hoverIndex) => this.moveDimension(dragIndex, hoverIndex)}
                                                 axis_transform={this.state.axisTransforms[axisName] || "def"}
                                                 handleAxisTransform={this.handleAxisTransform}
                                             />
                                         </div>
-                                    )
-                                })
-                            }
+                                    );
+                                })}
                             {/* if is an Axis */}
                             {/* Then there will only be one slider. No need to make it drag and drop */}
-                            {!this.state.selectedVariable.axisList &&
+                            {!this.state.selectedVariable.axisList && (
                                 <div key={this.state.selectedVariable.name} className="dimension">
-                                    <div className="text-right"><span>{this.state.selectedVariable.name}</span></div>
+                                    <div className="text-right">
+                                        <span>{this.state.selectedVariable.name}</span>
+                                    </div>
                                     <div className="right-content">
-                                        <DimensionSlider {...this.state.selectedVariable} onChange={(values) => this.handleDimensionValueChange(values)} />
+                                        <DimensionSlider
+                                            {...this.state.selectedVariable}
+                                            onChange={values => this.handleDimensionValueChange(values)}
+                                        />
                                     </div>
                                 </div>
-                            }
+                            )}
                         </div>
-                    }
+                    )}
                 </Modal.Body>
                 <Modal.Footer>
-                    <Button bsStyle="primary" onClick={(e) => {
-                        this.load()
-                    }}>Load</Button>
-                    <Button bsStyle="primary" onClick={(e) => {
-                        this.loadAndClose()
-                    }}>Load and Close</Button>
-                    <Button bsStyle="primary" onClick={(e) => {
-                        this.loadAs()
-                    }}>Load As</Button>
-                    <Button bsStyle="default" onClick={() => this.props.onTryClose()}>Close</Button>
+                    <Button
+                        bsStyle="primary"
+                        onClick={e => {
+                            this.load();
+                        }}
+                    >
+                        Load
+                    </Button>
+                    <Button
+                        bsStyle="primary"
+                        onClick={e => {
+                            this.loadAndClose();
+                        }}
+                    >
+                        Load and Close
+                    </Button>
+                    <Button
+                        bsStyle="primary"
+                        onClick={e => {
+                            this.loadAs();
+                        }}
+                    >
+                        Load As
+                    </Button>
+                    <Button bsStyle="default" onClick={() => this.props.onTryClose()}>
+                        Close
+                    </Button>
                 </Modal.Footer>
                 <Modal show={this.state.showRedefineVariableModal}>
                     <Modal.Header>
@@ -504,11 +540,13 @@ class FileTab extends Component {
                             <FormControl
                                 type="text"
                                 value={this.state.temporaryRedefinedVariableName}
-                                onChange={(e) => this.setState({ temporaryRedefinedVariableName: e.target.value })} />
+                                onChange={e => this.setState({ temporaryRedefinedVariableName: e.target.value })}
+                            />
                         </FormGroup>
                     </Modal.Body>
                     <Modal.Footer>
-                        <Button bsStyle="primary"
+                        <Button
+                            bsStyle="primary"
                             onClick={() => {
                                 if (this.state.temporaryRedefinedVariableName) {
                                     this.doneRedefineVariable();
@@ -517,95 +555,105 @@ class FileTab extends Component {
                                         showRedefineVariableModal: false
                                     });
                                 }
-                            }}>Confirm</Button>
+                            }}
+                        >
+                            Confirm
+                        </Button>
                         <Button onClick={() => this.setState({ showRedefineVariableModal: false })}>Close</Button>
                     </Modal.Footer>
                 </Modal>
-                {this.state.showFileInfoModal &&
-                    <FileInfoModal 
-                        show={this.state.showFileInfoModal}
-                        onTryClose={this.handleCloseFileInfoModal}
-                        file={selected_file_path}
-                    />
-                }
+                {this.state.showFileInfoModal && (
+                    <FileInfoModal show={this.state.showFileInfoModal} onTryClose={this.handleCloseFileInfoModal} file={selected_file_path} />
+                )}
                 <Dialog ref="dialog" />
-                {this.state.showFileExplorer &&
+                {this.state.showFileExplorer && (
                     <FileExplorer
                         show={true}
                         onTryClose={() => this.handleFileExplorerTryClose()}
-                        onFileSelected={(file) => this.handleFileSelected(file)}
-                        recent_path = {this.props.recent_path}
+                        onFileSelected={file => this.handleFileSelected(file)}
+                        recent_path={this.props.recent_path}
                     />
-                }
+                )}
             </div>
-        )
+        );
     }
 
     _formatvariablesAxes() {
-        return this.state.variablesAxes && [
-            <optgroup key="variables" label="---Variables---">{this._formatVariables(this.state.variablesAxes[0])}</optgroup>,
-            <optgroup key="axes" label="---Axes---">{this._formatAxes(this.state.variablesAxes[1])}</optgroup>
-        ]
+        return (
+            this.state.variablesAxes && [
+                <optgroup key="variables" label="---Variables---">
+                    {this._formatVariables(this.state.variablesAxes[0])}
+                </optgroup>,
+                <optgroup key="axes" label="---Axes---">
+                    {this._formatAxes(this.state.variablesAxes[1])}
+                </optgroup>
+            ]
+        );
     }
 
     _formatVariables(variables) {
-        return Object.keys(variables).sort().map((variableName) => {
-            // let variable = variables[variableName];
-            // let label = `${variableName} (${variable.shape.join(',')}) ${variable.name}`
-            var vars = variables;
-            var v = variableName;
-            var shape = ' (' + vars[v].shape[0];
-            for (let i = 1; i < vars[v].shape.length; ++i) {
-                shape += (',' + vars[v].shape[i]);
-            }
-            shape += ')';
-            // axes for the variable
-            var al = vars[v].axisList;
-            var axisList = '(' + al[0];
-            for (let i = 1; i < al.length; ++i) {
-                axisList += (', ' + al[i]);
-            }
-            axisList += ')';
-            // bounds are received for longitude and latitude
-            var boundsString = '';
-            if (vars[v].bounds) {
-                boundsString += ': (' + vars[v].bounds[0] + ', ' +
-                    vars[v].bounds[1] + ')';
-            }
-            // longitude, latitude for the variable
-            // these are different than the axes for the curvilinear or
-            // generic grids
-            var lonLat = null;
-            if (vars[v].lonLat) {
-                lonLat = '(' + vars[v].lonLat[0] + ', ' +
-                    vars[v].lonLat[1] + ')';
-            }
-            var label = v + shape + ' [' + vars[v].name + ', ' +
-                vars[v].units + boundsString + '] ' + ': ' + axisList;
-            if (lonLat) {
-                label += (', ' + lonLat);
-            }
-            if (vars[v].gridType) {
-                label += (', ' + vars[v].gridType);
-            }
+        return Object.keys(variables)
+            .sort()
+            .map(variableName => {
+                // let variable = variables[variableName];
+                // let label = `${variableName} (${variable.shape.join(',')}) ${variable.name}`
+                var vars = variables;
+                var v = variableName;
+                var shape = " (" + vars[v].shape[0];
+                for (let i = 1; i < vars[v].shape.length; ++i) {
+                    shape += "," + vars[v].shape[i];
+                }
+                shape += ")";
+                // axes for the variable
+                var al = vars[v].axisList;
+                var axisList = "(" + al[0];
+                for (let i = 1; i < al.length; ++i) {
+                    axisList += ", " + al[i];
+                }
+                axisList += ")";
+                // bounds are received for longitude and latitude
+                var boundsString = "";
+                if (vars[v].bounds) {
+                    boundsString += ": (" + vars[v].bounds[0] + ", " + vars[v].bounds[1] + ")";
+                }
+                // longitude, latitude for the variable
+                // these are different than the axes for the curvilinear or
+                // generic grids
+                var lonLat = null;
+                if (vars[v].lonLat) {
+                    lonLat = "(" + vars[v].lonLat[0] + ", " + vars[v].lonLat[1] + ")";
+                }
+                var label = v + shape + " [" + vars[v].name + ", " + vars[v].units + boundsString + "] " + ": " + axisList;
+                if (lonLat) {
+                    label += ", " + lonLat;
+                }
+                if (vars[v].gridType) {
+                    label += ", " + vars[v].gridType;
+                }
 
-            return <option key={v} value={v}>{label}</option>;
-        })
+                return (
+                    <option key={v} value={v}>
+                        {label}
+                    </option>
+                );
+            });
     }
 
     _formatAxes(axes) {
-        return Object.keys(axes).map((axisName) => {
+        return Object.keys(axes).map(axisName => {
             var v = axisName;
-            var shape = '(' + axes[v].shape[0];
+            var shape = "(" + axes[v].shape[0];
             for (let i = 1; i < axes[v].shape.length; ++i) {
-                shape += (',' + axes[v].shape[i]);
+                shape += "," + axes[v].shape[i];
             }
-            shape += ')';
-            var label = v + shape + '[' + axes[v].name + ', ' +
-                axes[v].units + ': (' +
-                axes[v].data[0] + ', ' +
-                axes[v].data[axes[v].data.length - 1] + ')]';
-            return <option key={axisName} value={axisName}>{label}</option>;
+            shape += ")";
+            var label =
+                v + shape + "[" + axes[v].name + ", " + axes[v].units + ": (" + axes[v].data[0] + ", " + axes[v].data[axes[v].data.length - 1] + ")]";
+            return (
+                <option key={axisName} value={axisName}>
+                    {label}
+                </option>
+            );
         });
     }
 
@@ -622,34 +670,40 @@ FileTab.propTypes = {
     loadVariables: PropTypes.func,
     switchTab: PropTypes.func,
     selectedTab: PropTypes.string,
-    setRecentFolderOpened: PropTypes.func,
-}
+    setRecentFolderOpened: PropTypes.func
+};
 
-var DimensionContainer = (props) => {
+var DimensionContainer = props => {
     const opacity = props.isDragging ? 0 : 1;
-    return props.connectDropTarget(props.connectDragPreview(
-    <div className="dimension" style={{ opacity }}>
-        <div className="axis-name text-right"><span>{props.axis.name}</span></div>
-        {props.connectDragSource(<div className="sort"><Glyphicon glyph="menu-hamburger" /></div>)}
-        <div className="right-content">
-            <DimensionSlider {...props.axis} onChange={props.handleDimensionValueChange} />
-        </div>
-        <AxisTransform
-            axis_name={props.axis.name}
-            axis_transform={props.axis_transform}
-            handleAxisTransform={props.handleAxisTransform}
-        />
-    </div>));
-}
+    return props.connectDropTarget(
+        props.connectDragPreview(
+            <div className="dimension" style={{ opacity }}>
+                <div className="axis-name text-right">
+                    <span>{props.axis.name}</span>
+                </div>
+                {props.connectDragSource(
+                    <div className="sort">
+                        <Glyphicon glyph="menu-hamburger" />
+                    </div>
+                )}
+                <div className="right-content">
+                    <DimensionSlider {...props.axis} onChange={props.handleDimensionValueChange} />
+                </div>
+                <AxisTransform axis_name={props.axis.name} axis_transform={props.axis_transform} handleAxisTransform={props.handleAxisTransform} />
+            </div>
+        )
+    );
+};
 
 var DimensionDnDContainer = _.flow(
-    DragSource(DragAndDropTypes.DIMENSION,
+    DragSource(
+        DragAndDropTypes.DIMENSION,
         {
-            beginDrag: (props) => {
+            beginDrag: props => {
                 return {
                     id: props.id,
                     index: props.index
-                }
+                };
             }
         },
         (connect, monitor) => {
@@ -674,8 +728,7 @@ var DimensionDnDContainer = _.flow(
                 const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
                 const clientOffset = monitor.getClientOffset();
                 const hoverClientY = clientOffset.y - hoverBoundingRect.top;
-                if ((dragIndex < hoverIndex && hoverClientY < hoverMiddleY)
-                    || (dragIndex > hoverIndex && hoverClientY > hoverMiddleY)) {
+                if ((dragIndex < hoverIndex && hoverClientY < hoverMiddleY) || (dragIndex > hoverIndex && hoverClientY > hoverMiddleY)) {
                     return;
                 }
                 props.moveDimension(dragIndex, hoverIndex);
@@ -684,28 +737,32 @@ var DimensionDnDContainer = _.flow(
                 // but it's good here for the sake of performance
                 // to avoid expensive index searches.
                 monitor.getItem().index = hoverIndex;
-            },
+            }
         },
         (connect, monitor) => {
             return {
                 connectDropTarget: connect.dropTarget(),
-                isOver: monitor.isOver(),
+                isOver: monitor.isOver()
             };
         }
-    ))(DimensionContainer);
+    )
+)(DimensionContainer);
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
     return {
         recent_path: state.present.cached_files.recent_local_path
-    }
-}
-const mapDispatchToProps = (dispatch) => {
+    };
+};
+const mapDispatchToProps = dispatch => {
     return {
         setRecentFolderOpened: function(path) {
             dispatch(Actions.setRecentLocalPath(path));
-        },
-    }
-}
+        }
+    };
+};
 
-export { getDefaultVariable }
-export default connect(mapStateToProps, mapDispatchToProps)(FileTab);
+export { getDefaultVariable };
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(FileTab);

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -443,6 +443,7 @@ Calculator.propTypes = {
     loadVariable: PropTypes.func
 };
 
+/* istanbul ignore next */
 const mapStateToProps = state => {
     return {
         variable_names: state.present.variables ? Object.keys(state.present.variables) : [],
@@ -450,6 +451,7 @@ const mapStateToProps = state => {
     };
 };
 
+/* istanbul ignore next */
 const mapDispatchToProps = dispatch => {
     return {
         removeVariable: name => dispatch(Actions.removeVariable(name)),

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -2,32 +2,167 @@ import React from "react";
 import { connect } from "react-redux";
 import { Modal, Button } from "react-bootstrap";
 import PropTypes from "prop-types";
-import Actions from '../../../constants/Actions.js'
-import VariableList from './VariableList.jsx'
-import InputArea from './InputArea.jsx'
-import CalculatorButtons from './CalculatorButtons.jsx'
-
+import { toast } from "react-toastify";
+import Actions from "../../../constants/Actions.js";
+import VariableList from "./VariableList.jsx";
+import InputArea from "./InputArea.jsx";
+import CalculatorButtons from "./CalculatorButtons.jsx";
+import { BINARY_OPERATORS, UNARY_OPERATORS } from "../../../constants/Constants";
 import "./Calculator.scss";
+
+const CALC_TYPES = {
+    var: "variable",
+    const: "constant"
+};
 
 class Calculator extends React.Component {
     constructor(props) {
         super(props);
+        this.state = {
+            new_variable_name: "",
+            calculation_left_side: undefined,
+            calculation_operator: undefined,
+            calculation_right_side: undefined
+        };
+        this.handleVariable = this.handleVariable.bind(this);
+        this.handleConstant = this.handleConstant.bind(this);
+        this.handleClear = this.handleClear.bind(this);
+        this.handleDelete = this.handleDelete.bind(this);
+        this.handleEnter = this.handleEnter.bind(this);
+        this.handleOperator = this.handleOperator.bind(this);
+        this.printCalculation = this.printCalculation.bind(this);
+    }
+
+    handleVariable(variable) {
+        if (!this.state.calculation_left_side) {
+            // Ex: ""
+            this.setState({
+                calculation_left_side: {
+                    value: variable.name,
+                    type: CALC_TYPES.var
+                }
+            });
+        } else if (!this.state.calculation_operator) {
+            // Ex: "u "
+            toast.warning("Please select an operator before adding a second argument.", { position: toast.POSITION.BOTTOM_CENTER });
+        } else if (!BINARY_OPERATORS.includes(this.state.calculation_operator)) {
+            // Ex: "regrid(x)"
+            toast.warning("Cannot add a second argument to unary operator", { position: toast.POSITION.BOTTOM_CENTER });
+        } else if (!this.state.calculation_right_side) {
+            // Ex: "u + "
+            this.setState({
+                calculation_right_side: {
+                    value: variable.name,
+                    type: CALC_TYPES.var
+                }
+            });
+        } else {
+            // Ex: "u + v"
+            toast.warning("The calculator expression appears to be full. Try deleting an operand first.", { position: toast.POSITION.BOTTOM_CENTER });
+        }
+    }
+
+    handleConstant(number) {
+        if (!this.state.calculation_left_side) {
+            // Ex: "" -> "1"
+            this.setState({
+                calculation_left_side: {
+                    value: number,
+                    type: CALC_TYPES.const
+                }
+            });
+        } else if (this.state.calculation_left_side.type === CALC_TYPES.const && !this.state.calculation_operator) {
+            // Ex: "2" -> "21"
+            this.setState({
+                calculation_left_side: {
+                    value: this.state.calculation_left_side.value + number,
+                    type: CALC_TYPES.const
+                }
+            });
+        } else if (this.state.calculation_left_side.type === CALC_TYPES.var && !this.state.calculation_operator) {
+            toast.warning("Cannot append a number to a variable. Try selecting an operator first.", { position: toast.POSITION.BOTTOM_CENTER });
+        } else if (this.state.calculation_operator) {
+            if (!BINARY_OPERATORS.includes(this.state.calculation_operator)) {
+                toast.warning("Cannot add a second argument to unary operator", { position: toast.POSITION.BOTTOM_CENTER });
+            } else if (!this.state.calculation_right_side) {
+                this.setState({
+                    calculation_right_side: {
+                        value: number,
+                        type: CALC_TYPES.const
+                    }
+                });
+            } else if (this.state.calculation_right_side.type === CALC_TYPES.var) {
+                toast.warning("The calculator expression appears to be full. Try deleting an operand first.", {
+                    position: toast.POSITION.BOTTOM_CENTER
+                });
+            }
+        }
+    }
+
+    handleClear() {
+        this.setState({
+            new_variable_name: "",
+            calculation_left_side: undefined,
+            calculation_operator: undefined,
+            calculation_right_side: undefined
+        });
+    }
+
+    handleDelete() {}
+
+    handleEnter() {
+        // send to vcs-js then clear
+    }
+
+    handleOperator(operator) {
+        if (this.state.calculation_operator) {
+            toast.warning("There is already an operator selected.", {
+                position: toast.POSITION.BOTTOM_CENTER
+            });
+        } else if (UNARY_OPERATORS.includes(operator)) {
+            this.setState({
+                calculation_operator: operator
+            });
+        } else if (!this.state.calculation_left_side) {
+            toast.warning("Binary operators require two operands. Please enter one first.", {
+                position: toast.POSITION.BOTTOM_CENTER
+            });
+        } else if (this.state.calculation_right_side) {
+            toast.warning("The calculator expression appears to be full. Try deleting an operand first.", {
+                position: toast.POSITION.BOTTOM_CENTER
+            });
+        } else {
+            this.setState({
+                calculation_operator: operator
+            });
+        }
+    }
+
+    printCalculation() {
+        const left = this.state.calculation_left_side ? this.state.calculation_left_side.value : "";
+        const right = this.state.calculation_right_side ? this.state.calculation_right_side.value : "";
+        const operator = this.state.calculation_operator ? this.state.calculation_operator : "";
+        return `${left} ${operator} ${right}`;
     }
 
     render() {
+        const calculation_string = this.printCalculation();
         return (
             <Modal show={this.props.show} onHide={this.props.close} bsSize="large">
                 <Modal.Header closeButton>
                     <Modal.Title>Calculator</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                    <div className="main-container">
-                        <VariableList 
-                            variables={this.props.variables}
-                            removeVariable={this.props.removeVariable}
+                    <div className="main-container" onKeyPress={this.handleKeyPress}>
+                        <VariableList variables={this.props.variables} removeVariable={this.props.removeVariable} />
+                        <InputArea new_variable_name={this.state.new_variable_name} calculation={calculation_string} onDrop={this.handleVariable} />
+                        <CalculatorButtons
+                            handleConstant={this.handleConstant}
+                            handleClear={this.handleClear}
+                            handleDelete={this.handleDelete}
+                            handleEnter={this.handleEnter}
+                            handleOperator={this.handleOperator}
                         />
-                        <InputArea />
-                        <CalculatorButtons />
                     </div>
                 </Modal.Body>
                 <Modal.Footer>
@@ -42,7 +177,7 @@ Calculator.propTypes = {
     show: PropTypes.bool,
     close: PropTypes.func,
     variables: PropTypes.arrayOf(PropTypes.string),
-    removeVariable: PropTypes.func,
+    removeVariable: PropTypes.func
 };
 
 const mapStateToProps = state => {
@@ -53,7 +188,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
     return {
-        removeVariable: (name) => dispatch(Actions.removeVariable(name))
+        removeVariable: name => dispatch(Actions.removeVariable(name))
     };
 };
 

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -2,6 +2,10 @@ import React from "react";
 import { connect } from "react-redux";
 import { Modal, Button } from "react-bootstrap";
 import PropTypes from "prop-types";
+import Actions from '../../../constants/Actions.js'
+import VariableList from './VariableList.jsx'
+import InputArea from './InputArea.jsx'
+import CalculatorButtons from './CalculatorButtons.jsx'
 
 import "./Calculator.scss";
 
@@ -18,55 +22,12 @@ class Calculator extends React.Component {
                 </Modal.Header>
                 <Modal.Body>
                     <div className="main-container">
-                        <div className="variable-list">
-                            <span>Variables</span>
-                            {this.props.variables.map(variable => {
-                                return <span style={{ display: "block" }}>{variable}</span>;
-                            })}
-                        </div>
-                        <div className="operation-list">
-                            <span>Operations</span>
-                            <span> Load u</span>
-                            <span> Load v</span>
-                            <span> u2 = u / 2</span>
-                            <span> v2 = v / 2</span>
-                            <span> u2_v2 = u + v</span>
-                        </div>
-                        <div className="input-container" style={{ display: "flex", justifyContent: "center" }}>
-                            <div className="input-wrapper">
-                                <input type="text" /> = <input type="text" disabled />
-                            </div>
-                        </div>
-                        <div className="calculator-buttons">
-                            <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                                <button className="calc-button" disabled="disabled" />
-                                <button className="calc-button numeric">7</button>
-                                <button className="calc-button numeric">8</button>
-                                <button className="calc-button numeric">9</button>
-                                <button className="calc-button math">+</button>
-                            </div>
-                            <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                                <button className="calc-button save-clear">Clear</button>
-                                <button className="calc-button numeric">4</button>
-                                <button className="calc-button numeric">5</button>
-                                <button className="calc-button numeric">6</button>
-                                <button className="calc-button math">-</button>
-                            </div>
-                            <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                                <button className="calc-button save-clear">Del</button>
-                                <button className="calc-button numeric">1</button>
-                                <button className="calc-button numeric">2</button>
-                                <button className="calc-button numeric">3</button>
-                                <button className="calc-button math">*</button>
-                            </div>
-                            <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                                <button className="calc-button save-clear">Enter</button>
-                                <button className="calc-button numeric">0</button>
-                                <button className="calc-button numeric">.</button>
-                                <button className="calc-button numeric">+/-</button>
-                                <button className="calc-button math">/</button>
-                            </div>
-                        </div>
+                        <VariableList 
+                            variables={this.props.variables}
+                            removeVariable={this.props.removeVariable}
+                        />
+                        <InputArea />
+                        <CalculatorButtons />
                     </div>
                 </Modal.Body>
                 <Modal.Footer>
@@ -80,7 +41,8 @@ class Calculator extends React.Component {
 Calculator.propTypes = {
     show: PropTypes.bool,
     close: PropTypes.func,
-    variables: PropTypes.oneOfType([PropTypes.array])
+    variables: PropTypes.arrayOf(PropTypes.string),
+    removeVariable: PropTypes.func,
 };
 
 const mapStateToProps = state => {
@@ -90,7 +52,9 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => {
-    return {};
+    return {
+        removeVariable: (name) => dispatch(Actions.removeVariable(name))
+    };
 };
 
 export default connect(

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -359,6 +359,9 @@ class Calculator extends React.Component {
             case "+":
                 op_string = "plus";
                 break;
+            case "**":
+                op_string = "power";
+                break;
             case "regrid":
                 op_string = "regrid";
                 break;

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -41,6 +41,7 @@ class Calculator extends React.Component {
         this.getOperand = this.getOperand.bind(this);
         this.handleDecimal = this.handleDecimal.bind(this);
         this.handlePlusMinus = this.handlePlusMinus.bind(this);
+        this.handleRegrid = this.handleRegrid.bind(this);
     }
 
     setInputFocus(state) {
@@ -531,6 +532,10 @@ class Calculator extends React.Component {
         }
     }
 
+    handleRegrid() {
+        console.log("regrid");
+    }
+
     render() {
         const calculation_string = this.printCalculation();
         return (
@@ -541,23 +546,25 @@ class Calculator extends React.Component {
                 <Modal.Body>
                     <div className="main-container">
                         <VariableList variables={this.props.variable_names} removeVariable={this.props.removeVariable} />
-                        <InputArea
-                            new_variable_name={this.state.new_variable_name}
-                            handleNewVariableName={this.handleNewVariableName}
-                            calculation={calculation_string}
-                            onDrop={this.handleVariable}
-                            setFocus={this.setInputFocus}
-                            new_variable_placeholder={this.state.placeholder_text}
-                        />
-                        <CalculatorButtons
-                            handleConstant={this.handleConstant}
-                            handleClear={this.handleClear}
-                            handleDelete={this.handleDelete}
-                            handleEnter={this.handleEnter}
-                            handleOperator={this.handleOperator}
-                            handleDecimal={this.handleDecimal}
-                            handlePlusMinus={this.handlePlusMinus}
-                        />
+                        <div className="calc-right-side">
+                            <InputArea
+                                new_variable_name={this.state.new_variable_name}
+                                handleNewVariableName={this.handleNewVariableName}
+                                calculation={calculation_string}
+                                onDrop={this.handleVariable}
+                                setFocus={this.setInputFocus}
+                                new_variable_placeholder={this.state.placeholder_text}
+                            />
+                            <CalculatorButtons
+                                handleConstant={this.handleConstant}
+                                handleClear={this.handleClear}
+                                handleDelete={this.handleDelete}
+                                handleEnter={this.handleEnter}
+                                handleOperator={this.handleOperator}
+                                handleDecimal={this.handleDecimal}
+                                handlePlusMinus={this.handlePlusMinus}
+                            />
+                        </div>
                     </div>
                 </Modal.Body>
                 <Modal.Footer>

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -1,105 +1,99 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { Modal, Button, Col, Row } from 'react-bootstrap'
-import PropTypes from 'prop-types'
+import React from "react";
+import { connect } from "react-redux";
+import { Modal, Button } from "react-bootstrap";
+import PropTypes from "prop-types";
 
-import './Calculator.scss'
+import "./Calculator.scss";
 
 class Calculator extends React.Component {
-    constructor(props){
-        super(props)
+    constructor(props) {
+        super(props);
     }
 
-    render(){
-        return(
+    render() {
+        return (
             <Modal show={this.props.show} onHide={this.props.close} bsSize="large">
                 <Modal.Header closeButton>
                     <Modal.Title>Calculator</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                    <Row>
-                        <Col sm={3} style={{borderColor: "red"}}>
-                            <div style={{display: "flex", flexDirection: "column", borderRight: "red 1px solid"}}>
-                                <div className="well">
-                                    <span>Variables</span>
-                                    { this.props.variables.map((variable) => {
-                                            return <span style={{display: "block"}}>{variable}</span>
-                                        })
-                                    }
-                                </div>
-                                <div className="well">
-                                    <span>Operations</span>
-                                    <span> Load u</span>
-                                    <span> Load v</span>
-                                    <span> u2 = u / 2</span>
-                                    <span> v2 = v / 2</span>
-                                    <span> u2_v2 = u + v</span>
-                                </div>
+                    <div className="main-container">
+                        <div className="variable-list">
+                            <span>Variables</span>
+                            {this.props.variables.map(variable => {
+                                return <span style={{ display: "block" }}>{variable}</span>;
+                            })}
+                        </div>
+                        <div className="operation-list">
+                            <span>Operations</span>
+                            <span> Load u</span>
+                            <span> Load v</span>
+                            <span> u2 = u / 2</span>
+                            <span> v2 = v / 2</span>
+                            <span> u2_v2 = u + v</span>
+                        </div>
+                        <div className="input-container" style={{ display: "flex", justifyContent: "center" }}>
+                            <div className="input-wrapper">
+                                <input type="text" /> = <input type="text" disabled />
                             </div>
-                        </Col>
-                        <Col sm={9}>
-                            <div style={{display: "flex", flexDirection: "column"}}>
-                                <div className="input-container" style={{display: "flex", justifyContent: "center"}}>
-                                    <input type="text"/> = <input type="text" disabled/>
-                                </div>
-                                <div style={{display: "flex", flexWrap: "nowrap"}}>
-                                    <button className="calc-button" style={{}} disabled="disabled"></button>
-                                    <button className="calc-button numeric" style={{}}>7</button>
-                                    <button className="calc-button numeric" style={{}}>8</button>
-                                    <button className="calc-button numeric" style={{}}>9</button>
-                                    <button className="calc-button math" style={{}}>+</button>
-                                </div>
-                                <div style={{display: "flex", flexWrap: "nowrap"}}>
-                                    <button className="calc-button save-clear" style={{}}>Clear</button>
-                                    <button className="calc-button numeric" style={{}}>4</button>
-                                    <button className="calc-button numeric" style={{}}>5</button>
-                                    <button className="calc-button numeric" style={{}}>6</button>
-                                    <button className="calc-button math" style={{}}>-</button>
-                                </div>
-                                <div style={{display: "flex", flexWrap: "nowrap"}}>
-                                    <button className="calc-button save-clear" style={{}}>Del</button>
-                                    <button className="calc-button numeric" style={{}}>1</button>
-                                    <button className="calc-button numeric" style={{}}>2</button>
-                                    <button className="calc-button numeric" style={{}}>3</button>
-                                    <button className="calc-button math" style={{}}>*</button>
-                                </div>
-                                <div style={{display: "flex", flexWrap: "nowrap"}}>
-                                    <button className="calc-button save-clear" style={{}}>Enter</button>
-                                    <button className="calc-button numeric" style={{}}>0</button>
-                                    <button className="calc-button numeric" style={{}}>.</button>
-                                    <button className="calc-button numeric" style={{}}>+/-</button>
-                                    <button className="calc-button math" style={{}}>/</button>
-                                </div>
+                        </div>
+                        <div className="calculator-buttons">
+                            <div style={{ display: "flex", flexWrap: "nowrap" }}>
+                                <button className="calc-button" disabled="disabled" />
+                                <button className="calc-button numeric">7</button>
+                                <button className="calc-button numeric">8</button>
+                                <button className="calc-button numeric">9</button>
+                                <button className="calc-button math">+</button>
                             </div>
-                        </Col>
-                    </Row>
+                            <div style={{ display: "flex", flexWrap: "nowrap" }}>
+                                <button className="calc-button save-clear">Clear</button>
+                                <button className="calc-button numeric">4</button>
+                                <button className="calc-button numeric">5</button>
+                                <button className="calc-button numeric">6</button>
+                                <button className="calc-button math">-</button>
+                            </div>
+                            <div style={{ display: "flex", flexWrap: "nowrap" }}>
+                                <button className="calc-button save-clear">Del</button>
+                                <button className="calc-button numeric">1</button>
+                                <button className="calc-button numeric">2</button>
+                                <button className="calc-button numeric">3</button>
+                                <button className="calc-button math">*</button>
+                            </div>
+                            <div style={{ display: "flex", flexWrap: "nowrap" }}>
+                                <button className="calc-button save-clear">Enter</button>
+                                <button className="calc-button numeric">0</button>
+                                <button className="calc-button numeric">.</button>
+                                <button className="calc-button numeric">+/-</button>
+                                <button className="calc-button math">/</button>
+                            </div>
+                        </div>
+                    </div>
                 </Modal.Body>
                 <Modal.Footer>
                     <Button onClick={this.props.close}>Close</Button>
                 </Modal.Footer>
             </Modal>
-        )
+        );
     }
 }
 
 Calculator.propTypes = {
     show: PropTypes.bool,
     close: PropTypes.func,
-    variables: PropTypes.oneOfType([
-        PropTypes.array,
-    ]),
-}
+    variables: PropTypes.oneOfType([PropTypes.array])
+};
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
     return {
-        variables: state.present.variables ? Object.keys(state.present.variables) : [],
-    }
-}
+        variables: state.present.variables ? Object.keys(state.present.variables) : []
+    };
+};
 
-const mapDispatchToProps = (dispatch) => {
-    return {
-        
-    }
-}
+const mapDispatchToProps = dispatch => {
+    return {};
+};
 
-export default connect(mapStateToProps, mapDispatchToProps)(Calculator)
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Calculator);

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -11,7 +11,7 @@ import CalculatorButtons from "./CalculatorButtons.jsx";
 import { BINARY_OPERATORS, UNARY_OPERATORS } from "../../../constants/Constants";
 import "./Calculator.scss";
 
-const CALC_TYPES = {
+export const CALC_TYPES = {
     var: "variable",
     const: "constant"
 };
@@ -465,6 +465,7 @@ const mapDispatchToProps = dispatch => {
     };
 };
 
+export { Calculator as PureCalculator };
 export default connect(
     mapStateToProps,
     mapDispatchToProps

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -40,6 +40,7 @@ class Calculator extends React.Component {
         this.isValidCalculation = this.isValidCalculation.bind(this);
         this.getOperand = this.getOperand.bind(this);
         this.handleDecimal = this.handleDecimal.bind(this);
+        this.handlePlusMinus = this.handlePlusMinus.bind(this);
     }
 
     setInputFocus(state) {
@@ -461,6 +462,72 @@ class Calculator extends React.Component {
         }
     }
 
+    handlePlusMinus() {
+        if (!this.state.calculation_left_side) {
+            // Ex: "" -> ""
+            toast.warning("A number must be entered to change signs.", { position: toast.POSITION.BOTTOM_CENTER });
+        } else if (this.state.calculation_left_side.type === CALC_TYPES.const && !this.state.calculation_operator) {
+            if (this.state.calculation_left_side.value.startsWith("-")) {
+                // Ex: "-1" -> "1"
+                const new_value = this.state.calculation_left_side.value.slice(1, this.state.calculation_left_side.value.length);
+                this.setState({
+                    calculation_left_side: {
+                        value: new_value,
+                        type: CALC_TYPES.const
+                    },
+                    placeholder_text: this.getPlaceholderText(new_value)
+                });
+            } else {
+                // Ex: "1" -> "-1"
+                const new_value = "-" + this.state.calculation_left_side.value;
+                this.setState({
+                    calculation_left_side: {
+                        value: new_value,
+                        type: CALC_TYPES.const
+                    },
+                    placeholder_text: this.getPlaceholderText(new_value)
+                });
+            }
+        } else if (this.state.calculation_left_side.type === CALC_TYPES.var && !this.state.calculation_operator) {
+            toast.warning(
+                "Changing the sign of a variable is not supported in this manner. Use the 'subtract' operator with a single variable to do this.",
+                { position: toast.POSITION.BOTTOM_CENTER }
+            );
+        } else if (this.state.calculation_operator) {
+            if (!BINARY_OPERATORS.includes(this.state.calculation_operator)) {
+                toast.warning("Cannot add a second argument to unary operator", { position: toast.POSITION.BOTTOM_CENTER });
+            } else if (!this.state.calculation_right_side) {
+                toast.warning("A number must be entered to change signs.", { position: toast.POSITION.BOTTOM_CENTER });
+            } else if (this.state.calculation_right_side.type === CALC_TYPES.const) {
+                if (this.state.calculation_right_side.value.startsWith("-")) {
+                    // Ex: "-1" -> "1"
+                    const new_value = this.state.calculation_right_side.value.slice(1, this.state.calculation_right_side.value.length);
+                    this.setState({
+                        calculation_right_side: {
+                            value: new_value,
+                            type: CALC_TYPES.const
+                        },
+                        placeholder_text: this.getPlaceholderText(this.state.calculation_left_side, this.state.calculation_operator, new_value)
+                    });
+                } else {
+                    const new_value = "-" + this.state.calculation_right_side.value;
+                    this.setState({
+                        calculation_right_side: {
+                            value: new_value,
+                            type: CALC_TYPES.const
+                        },
+                        placeholder_text: this.getPlaceholderText(this.state.calculation_left_side, this.state.calculation_operator, new_value)
+                    });
+                }
+            } else if (this.state.calculation_right_side.type === CALC_TYPES.var) {
+                toast.warning(
+                    "Changing the sign of a variable is not supported in this manner. Use the 'subtract' operator with a single variable to do this.",
+                    { position: toast.POSITION.BOTTOM_CENTER }
+                );
+            }
+        }
+    }
+
     render() {
         const calculation_string = this.printCalculation();
         return (
@@ -486,6 +553,7 @@ class Calculator extends React.Component {
                             handleEnter={this.handleEnter}
                             handleOperator={this.handleOperator}
                             handleDecimal={this.handleDecimal}
+                            handlePlusMinus={this.handlePlusMinus}
                         />
                     </div>
                 </Modal.Body>

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { Modal, Button, Col, Row } from 'react-bootstrap'
+import PropTypes from 'prop-types'
+
+import './Calculator.scss'
+
+class Calculator extends React.Component {
+    constructor(props){
+        super(props)
+    }
+
+    render(){
+        return(
+            <Modal show={this.props.show} onHide={this.props.close} bsSize="large">
+                <Modal.Header closeButton>
+                    <Modal.Title>Calculator</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <Row>
+                        <Col sm={3} style={{borderColor: "red"}}>
+                            <div style={{display: "flex", flexDirection: "column", borderRight: "red 1px solid"}}>
+                                <div className="well">
+                                    <span>Variables</span>
+                                    { this.props.variables.map((variable) => {
+                                            return <span style={{display: "block"}}>{variable}</span>
+                                        })
+                                    }
+                                </div>
+                                <div className="well">
+                                    <span>Operations</span>
+                                    <span> Load u</span>
+                                    <span> Load v</span>
+                                    <span> u2 = u / 2</span>
+                                    <span> v2 = v / 2</span>
+                                    <span> u2_v2 = u + v</span>
+                                </div>
+                            </div>
+                        </Col>
+                        <Col sm={9}>
+                            <div style={{display: "flex", flexDirection: "column"}}>
+                                <div className="input-container" style={{display: "flex", justifyContent: "center"}}>
+                                    <input type="text"/> = <input type="text" disabled/>
+                                </div>
+                                <div style={{display: "flex", flexWrap: "nowrap"}}>
+                                    <button className="calc-button" style={{}} disabled="disabled"></button>
+                                    <button className="calc-button numeric" style={{}}>7</button>
+                                    <button className="calc-button numeric" style={{}}>8</button>
+                                    <button className="calc-button numeric" style={{}}>9</button>
+                                    <button className="calc-button math" style={{}}>+</button>
+                                </div>
+                                <div style={{display: "flex", flexWrap: "nowrap"}}>
+                                    <button className="calc-button save-clear" style={{}}>Clear</button>
+                                    <button className="calc-button numeric" style={{}}>4</button>
+                                    <button className="calc-button numeric" style={{}}>5</button>
+                                    <button className="calc-button numeric" style={{}}>6</button>
+                                    <button className="calc-button math" style={{}}>-</button>
+                                </div>
+                                <div style={{display: "flex", flexWrap: "nowrap"}}>
+                                    <button className="calc-button save-clear" style={{}}>Del</button>
+                                    <button className="calc-button numeric" style={{}}>1</button>
+                                    <button className="calc-button numeric" style={{}}>2</button>
+                                    <button className="calc-button numeric" style={{}}>3</button>
+                                    <button className="calc-button math" style={{}}>*</button>
+                                </div>
+                                <div style={{display: "flex", flexWrap: "nowrap"}}>
+                                    <button className="calc-button save-clear" style={{}}>Enter</button>
+                                    <button className="calc-button numeric" style={{}}>0</button>
+                                    <button className="calc-button numeric" style={{}}>.</button>
+                                    <button className="calc-button numeric" style={{}}>+/-</button>
+                                    <button className="calc-button math" style={{}}>/</button>
+                                </div>
+                            </div>
+                        </Col>
+                    </Row>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button onClick={this.props.close}>Close</Button>
+                </Modal.Footer>
+            </Modal>
+        )
+    }
+}
+
+Calculator.propTypes = {
+    show: PropTypes.bool,
+    close: PropTypes.func,
+    variables: PropTypes.oneOfType([
+        PropTypes.array,
+    ]),
+}
+
+const mapStateToProps = (state) => {
+    return {
+        variables: state.present.variables ? Object.keys(state.present.variables) : [],
+    }
+}
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Calculator)

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -382,6 +382,9 @@ class Calculator extends React.Component {
             } else if (code === 46) {
                 // delete key
                 this.handleClear();
+            } else if (code === 190 || code === 110) {
+                // period key
+                this.handleDecimal();
             } else if (code === 107 || (code === 187 && event.shiftKey)) {
                 // plus key
                 this.handleOperator("+");

--- a/frontend/src/js/components/modals/Calculator/Calculator.jsx
+++ b/frontend/src/js/components/modals/Calculator/Calculator.jsx
@@ -75,7 +75,7 @@ class Calculator extends React.Component {
             // Ex: "2" -> "21"
             this.setState({
                 calculation_left_side: {
-                    value: this.state.calculation_left_side.value + number,
+                    value: this.state.calculation_left_side.value + "" + number,
                     type: CALC_TYPES.const
                 }
             });
@@ -88,6 +88,13 @@ class Calculator extends React.Component {
                 this.setState({
                     calculation_right_side: {
                         value: number,
+                        type: CALC_TYPES.const
+                    }
+                });
+            } else if (this.state.calculation_right_side.type === CALC_TYPES.const) {
+                this.setState({
+                    calculation_right_side: {
+                        value: this.state.calculation_right_side.value + "" + number,
                         type: CALC_TYPES.const
                     }
                 });

--- a/frontend/src/js/components/modals/Calculator/Calculator.scss
+++ b/frontend/src/js/components/modals/Calculator/Calculator.scss
@@ -10,32 +10,37 @@ $math-button-lighter-color: rgb(255, 245, 223);
 $math-button-darker-color: rgb(255, 245, 132);
 $math-button-hover-color: rgb(222, 210, 83);
 
+$advanced-button-lighter-color: rgb(230, 255, 223);
+$advanced-button-darker-color: rgb(153, 255, 132);
+$advanced-button-hover-color: rgb(90, 222, 83);
+
 .main-container {
     display: grid;
     grid-template-columns: 2fr 7fr;
-    grid-template-rows: 80px 320px;
     grid-column-gap: 15px;
 }
 .variable-list {
     grid-column: 1 / 2;
-    grid-row: 1 / 3;
+    grid-row: 1 / 2;
     height: 100%;
     box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.1);
     .scroll-area {
         border: 1px #d3d3d373 solid;
     }
 }
+
 // .operation-list {
 //     grid-column: 1 / 2;
 //     grid-row: 2 / 3;
 // }
+
+.calc-right-side {
+    display: flex;
+    flex-direction: column;
+}
 .input-area {
-    grid-column: 2 / 3;
-    grid-row: 1 / 2;
-    border-top: lightgray 1px solid;
-    border-left: lightgray 1px solid;
-    border-right: lightgray 1px solid;
-    border-bottom: lightgray 1px solid;
+    height: 80px;
+    border: lightgray 1px solid;
     &.drop-hint {
         border-color: cyan;
     }
@@ -52,11 +57,11 @@ $math-button-hover-color: rgb(222, 210, 83);
         grid-column: 1 / 2;
         grid-row: 1 / 2;
     }
-    #new-variable-name-help-text  {
+    #new-variable-name-help-text {
         grid-column: 1 / 2;
         grid-row: 2 / 3;
     }
-    #assignment  {
+    #assignment {
         grid-column: 2 / 3;
         grid-row: 1 / 2;
         line-height: 25px;
@@ -75,14 +80,21 @@ $math-button-hover-color: rgb(222, 210, 83);
     }
 }
 .calculator-buttons {
-    grid-column: 2 / 3;
-    grid-row: 2 / 3;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    border-bottom: lightgray 1px solid;
-    border-left: lightgray 1px solid;
-    border-right: lightgray 1px solid;
+    // The contents of this div is the individual buttons
+    // We now define a grid for those buttons to populate
+    height: 320px;
+    width: 100%;
+    border: lightgray 1px solid;
+    border-top: none;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+    grid-template-rows: repeat(5, minmax(28px, 45px));
+    align-content: end;
+    grid-template-areas:
+        "regrid power . . ."// periods indicate blank cells
+        "unused seven eight nine divide""clear four five six multiply"
+        "delete one two three subtract"
+        "enter zero decimal plusminus add";
 }
 
 button.calc-button {
@@ -137,10 +149,95 @@ button.calc-button {
             background-image: linear-gradient(to bottom, $math-button-lighter-color, $math-button-hover-color);
         }
     }
+
+    &.advanced {
+        background: $advanced-button-lighter-color;
+        background-image: -webkit-linear-gradient(top, $advanced-button-lighter-color, $advanced-button-darker-color);
+        background-image: -moz-linear-gradient(top, $advanced-button-lighter-color, $advanced-button-darker-color);
+        background-image: -ms-linear-gradient(top, $advanced-button-lighter-color, $advanced-button-darker-color);
+        background-image: -o-linear-gradient(top, $advanced-button-lighter-color, $advanced-button-darker-color);
+        background-image: linear-gradient(to bottom, $advanced-button-lighter-color, $advanced-button-darker-color);
+        &:hover {
+            background: $advanced-button-lighter-color;
+            background-image: -webkit-linear-gradient(top, $advanced-button-lighter-color, $advanced-button-hover-color);
+            background-image: -moz-linear-gradient(top, $advanced-button-lighter-color, $advanced-button-hover-color);
+            background-image: -ms-linear-gradient(top, $advanced-button-lighter-color, $advanced-button-hover-color);
+            background-image: -o-linear-gradient(top, $advanced-button-lighter-color, $advanced-button-hover-color);
+            background-image: linear-gradient(to bottom, $advanced-button-lighter-color, $advanced-button-hover-color);
+        }
+    }
 }
 
+// We individually map each button to a named grid location.
+// Hopefully this should make rearranging items easy (E.g. for media queries)
+#regrid {
+    grid-area: regrid;
+}
+#power {
+    grid-area: power;
+}
+#unused {
+    grid-area: unused;
+}
+#seven {
+    grid-area: seven;
+}
+#eight {
+    grid-area: eight;
+}
+#nine {
+    grid-area: nine;
+}
+#divide {
+    grid-area: divide;
+}
+#clear {
+    grid-area: clear;
+}
+#four {
+    grid-area: four;
+}
+#five {
+    grid-area: five;
+}
+#six {
+    grid-area: six;
+}
+#multiply {
+    grid-area: multiply;
+}
+#delete {
+    grid-area: delete;
+}
+#one {
+    grid-area: one;
+}
+#two {
+    grid-area: two;
+}
+#three {
+    grid-area: three;
+}
+#subtract {
+    grid-area: subtract;
+}
+#enter {
+    grid-area: enter;
+}
+#zero {
+    grid-area: zero;
+}
+#decimal {
+    grid-area: decimal;
+}
+#plusminus {
+    grid-area: plusminus;
+}
+#add {
+    grid-area: add;
+}
 
-@media(min-width: 992px) {
+@media (min-width: 992px) {
     .input-area {
         padding: 9px 15px;
     }

--- a/frontend/src/js/components/modals/Calculator/Calculator.scss
+++ b/frontend/src/js/components/modals/Calculator/Calculator.scss
@@ -79,6 +79,7 @@ $advanced-button-hover-color: rgb(90, 222, 83);
         grid-row: 2 / 3;
     }
 }
+
 .calculator-buttons {
     // The contents of this div is the individual buttons
     // We now define a grid for those buttons to populate
@@ -91,13 +92,30 @@ $advanced-button-hover-color: rgb(90, 222, 83);
     grid-template-rows: repeat(5, minmax(28px, 45px));
     align-content: end;
     grid-template-areas:
-        "regrid power . . ."// periods indicate blank cells
-        "unused seven eight nine divide""clear four five six multiply"
+    // periods indicate blank cells
+        "regrid power . . ."
+        "unused seven eight nine divide"
+        "clear four five six multiply"
         "delete one two three subtract"
         "enter zero decimal plusminus add";
+    .dropdown.btn-group {
+        // This section fixes some bootstrap css issues
+        // flex settings fix button sizing
+        // border settings make dropdown buttons consistent with other buttons
+        // width setting overwrites a previous rule that we dont want applied to the carat button
+        display: flex;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        button.btn:first-child {
+            flex-grow: 1;
+        }
+        .dropdown-toggle.calc-button {
+            width: unset;
+        }
+    }
 }
 
-button.calc-button {
+.calc-button {
     width: 100%;
     font-size: 15px;
     font-weight: 700;
@@ -166,6 +184,11 @@ button.calc-button {
             background-image: linear-gradient(to bottom, $advanced-button-lighter-color, $advanced-button-hover-color);
         }
     }
+}
+
+.sub-text {
+    font-size: smaller;
+    font-weight: 100;
 }
 
 // We individually map each button to a named grid location.

--- a/frontend/src/js/components/modals/Calculator/Calculator.scss
+++ b/frontend/src/js/components/modals/Calculator/Calculator.scss
@@ -32,9 +32,6 @@ $math-button-hover-color: rgb(222, 210, 83);
 .input-area {
     grid-column: 2 / 3;
     grid-row: 1 / 2;
-    display: flex;
-    justify-content: center;
-    align-items: center;
     border-top: lightgray 1px solid;
     border-left: lightgray 1px solid;
     border-right: lightgray 1px solid;
@@ -45,23 +42,36 @@ $math-button-hover-color: rgb(222, 210, 83);
     &.drop-success {
         border-color: lime;
     }
-    .input-wrapper {
+    display: grid;
+    grid-template-columns: 10fr minmax(15px, 1fr) 14fr;
+    grid-template-rows: 1fr 1fr;
+    input {
+        font-size: 18px;
+    }
+    #new-variable-name {
+        grid-column: 1 / 2;
+        grid-row: 1 / 2;
+    }
+    #new-variable-name-help-text  {
+        grid-column: 1 / 2;
+        grid-row: 2 / 3;
+    }
+    #assignment  {
+        grid-column: 2 / 3;
+        grid-row: 1 / 2;
+        line-height: 25px;
         display: flex;
-        width: 80%;
-        margin-bottom: 5px;
-        input {
-            font-size: 18px;
-        }
-        .new-variable-name {
-            flex-grow: 1;
-        }
-        span.equals {
-            margin: 0 5px;
-        }
-        .calculation {
-            flex-grow: 5;
-            background-color: rgb(238, 239, 238);
-        }
+        justify-content: center;
+        align-items: center;
+    }
+    #calculation {
+        grid-column: 3 / 4;
+        grid-row: 1 / 2;
+        background-color: rgb(238, 239, 238);
+    }
+    #calculation-help-text {
+        grid-column: 3 / 4;
+        grid-row: 2 / 3;
     }
 }
 .calculator-buttons {
@@ -126,5 +136,12 @@ button.calc-button {
             background-image: -o-linear-gradient(top, $math-button-lighter-color, $math-button-hover-color);
             background-image: linear-gradient(to bottom, $math-button-lighter-color, $math-button-hover-color);
         }
+    }
+}
+
+
+@media(min-width: 992px) {
+    .input-area {
+        padding: 9px 15px;
     }
 }

--- a/frontend/src/js/components/modals/Calculator/Calculator.scss
+++ b/frontend/src/js/components/modals/Calculator/Calculator.scss
@@ -39,6 +39,12 @@ $math-button-hover-color: rgb(222, 210, 83);
     border-left: lightgray 1px solid;
     border-right: lightgray 1px solid;
     border-bottom: lightgray 1px solid;
+    &.drop-hint {
+        border-color: cyan;
+    }
+    &.drop-success {
+        border-color: lime;
+    }
     .input-wrapper {
         display: flex;
         width: 80%;
@@ -54,7 +60,7 @@ $math-button-hover-color: rgb(222, 210, 83);
         }
         .calculation {
             flex-grow: 5;
-            background-color: rgba(128, 128, 128, 0.149);
+            background-color: rgb(238, 239, 238);
         }
     }
 }

--- a/frontend/src/js/components/modals/Calculator/Calculator.scss
+++ b/frontend/src/js/components/modals/Calculator/Calculator.scss
@@ -1,0 +1,70 @@
+
+$numeric-button-lighter-color: rgb(233, 246, 255);
+$numeric-button-darker-color: rgb(135, 183, 214);
+$numeric-button-hover-color: rgb(84, 155, 203);
+
+$save-clear-button-lighter-color: rgb(255, 223, 223);
+$save-clear-button-darker-color: rgb(255, 132, 132);
+$save-clear-button-hover-color: rgb(203, 88, 88);
+
+$math-button-lighter-color: rgb(255, 245, 223);
+$math-button-darker-color: rgb(255, 245, 132);
+$math-button-hover-color: rgb(222, 210, 83);
+
+.input-container{
+    
+}
+
+button.calc-button{
+    width: 100%;
+    font-size: 15px;
+    font-weight: 700;
+    &.numeric{
+        background: $numeric-button-lighter-color;
+        background-image: -webkit-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-darker-color);
+        background-image: -moz-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-darker-color);
+        background-image: -ms-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-darker-color);
+        background-image: -o-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-darker-color);
+        background-image: linear-gradient(to bottom, $numeric-button-lighter-color, $numeric-button-darker-color);
+        &:hover{
+            background: $numeric-button-lighter-color;
+            background-image: -webkit-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-hover-color);
+            background-image: -moz-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-hover-color);
+            background-image: -ms-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-hover-color);
+            background-image: -o-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-hover-color);
+            background-image: linear-gradient(to bottom, $numeric-button-lighter-color, $numeric-button-hover-color);
+        }
+    }
+    &.save-clear{
+        background: $save-clear-button-lighter-color;
+        background-image: -webkit-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-darker-color);
+        background-image: -moz-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-darker-color);
+        background-image: -ms-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-darker-color);
+        background-image: -o-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-darker-color);
+        background-image: linear-gradient(to bottom, $save-clear-button-lighter-color, $save-clear-button-darker-color);
+        &:hover{
+            background: $save-clear-button-lighter-color;
+            background-image: -webkit-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-hover-color);
+            background-image: -moz-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-hover-color);
+            background-image: -ms-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-hover-color);
+            background-image: -o-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-hover-color);
+            background-image: linear-gradient(to bottom, $save-clear-button-lighter-color, $save-clear-button-hover-color);
+        }
+    }
+    &.math{
+        background: $math-button-lighter-color;
+        background-image: -webkit-linear-gradient(top, $math-button-lighter-color, $math-button-darker-color);
+        background-image: -moz-linear-gradient(top, $math-button-lighter-color, $math-button-darker-color);
+        background-image: -ms-linear-gradient(top, $math-button-lighter-color, $math-button-darker-color);
+        background-image: -o-linear-gradient(top, $math-button-lighter-color, $math-button-darker-color);
+        background-image: linear-gradient(to bottom, $math-button-lighter-color, $math-button-darker-color);
+        &:hover{
+            background: $math-button-lighter-color;
+            background-image: -webkit-linear-gradient(top, $math-button-lighter-color, $math-button-hover-color);
+            background-image: -moz-linear-gradient(top, $math-button-lighter-color, $math-button-hover-color);
+            background-image: -ms-linear-gradient(top, $math-button-lighter-color, $math-button-hover-color);
+            background-image: -o-linear-gradient(top, $math-button-lighter-color, $math-button-hover-color);
+            background-image: linear-gradient(to bottom, $math-button-lighter-color, $math-button-hover-color);
+        }
+    }
+}

--- a/frontend/src/js/components/modals/Calculator/Calculator.scss
+++ b/frontend/src/js/components/modals/Calculator/Calculator.scss
@@ -1,4 +1,3 @@
-
 $numeric-button-lighter-color: rgb(233, 246, 255);
 $numeric-button-darker-color: rgb(135, 183, 214);
 $numeric-button-hover-color: rgb(84, 155, 203);
@@ -11,42 +10,77 @@ $math-button-lighter-color: rgb(255, 245, 223);
 $math-button-darker-color: rgb(255, 245, 132);
 $math-button-hover-color: rgb(222, 210, 83);
 
-.main-container{
+.main-container {
     display: grid;
-    grid-template-columns: 1fr 4fr;
-    grid-template-rows: 250px 250px;
+    grid-template-columns: 2fr 7fr;
+    grid-template-rows: 80px 320px;
+    grid-column-gap: 15px;
 }
-.variable-list{
+.variable-list {
     grid-column: 1 / 2;
-    grid-row: 1 / 2; 
+    grid-row: 1 / 3;
+    height: 100%;
+    box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.1);
+    .scroll-area {
+        border: 1px #d3d3d373 solid;
+    }
 }
-.operation-list {
-    grid-column: 1 / 2;
-    grid-row: 2 / 3; 
+// .operation-list {
+//     grid-column: 1 / 2;
+//     grid-row: 2 / 3;
+// }
+.input-area {
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-top: lightgray 1px solid;
+    border-left: lightgray 1px solid;
+    border-right: lightgray 1px solid;
+    border-bottom: lightgray 1px solid;
+    .input-wrapper {
+        display: flex;
+        width: 80%;
+        margin-bottom: 5px;
+        input {
+            font-size: 18px;
+        }
+        .new-variable-name {
+            flex-grow: 1;
+        }
+        span.equals {
+            margin: 0 5px;
+        }
+        .calculation {
+            flex-grow: 5;
+            background-color: rgba(128, 128, 128, 0.149);
+        }
+    }
 }
-.input-container {
-    grid-column: 2 / 3; 
-    grid-row: 1 / 2; 
-}
-.calculator-buttons{
-    grid-column: 2 / 3; 
-    grid-row: 2 / 3; 
+.calculator-buttons {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    border-bottom: lightgray 1px solid;
+    border-left: lightgray 1px solid;
+    border-right: lightgray 1px solid;
 }
 
-
-
-button.calc-button{
+button.calc-button {
     width: 100%;
     font-size: 15px;
     font-weight: 700;
-    &.numeric{
+    &.numeric {
         background: $numeric-button-lighter-color;
         background-image: -webkit-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-darker-color);
         background-image: -moz-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-darker-color);
         background-image: -ms-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-darker-color);
         background-image: -o-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-darker-color);
         background-image: linear-gradient(to bottom, $numeric-button-lighter-color, $numeric-button-darker-color);
-        &:hover{
+        &:hover {
             background: $numeric-button-lighter-color;
             background-image: -webkit-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-hover-color);
             background-image: -moz-linear-gradient(top, $numeric-button-lighter-color, $numeric-button-hover-color);
@@ -55,14 +89,14 @@ button.calc-button{
             background-image: linear-gradient(to bottom, $numeric-button-lighter-color, $numeric-button-hover-color);
         }
     }
-    &.save-clear{
+    &.save-clear {
         background: $save-clear-button-lighter-color;
         background-image: -webkit-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-darker-color);
         background-image: -moz-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-darker-color);
         background-image: -ms-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-darker-color);
         background-image: -o-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-darker-color);
         background-image: linear-gradient(to bottom, $save-clear-button-lighter-color, $save-clear-button-darker-color);
-        &:hover{
+        &:hover {
             background: $save-clear-button-lighter-color;
             background-image: -webkit-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-hover-color);
             background-image: -moz-linear-gradient(top, $save-clear-button-lighter-color, $save-clear-button-hover-color);
@@ -71,14 +105,14 @@ button.calc-button{
             background-image: linear-gradient(to bottom, $save-clear-button-lighter-color, $save-clear-button-hover-color);
         }
     }
-    &.math{
+    &.math {
         background: $math-button-lighter-color;
         background-image: -webkit-linear-gradient(top, $math-button-lighter-color, $math-button-darker-color);
         background-image: -moz-linear-gradient(top, $math-button-lighter-color, $math-button-darker-color);
         background-image: -ms-linear-gradient(top, $math-button-lighter-color, $math-button-darker-color);
         background-image: -o-linear-gradient(top, $math-button-lighter-color, $math-button-darker-color);
         background-image: linear-gradient(to bottom, $math-button-lighter-color, $math-button-darker-color);
-        &:hover{
+        &:hover {
             background: $math-button-lighter-color;
             background-image: -webkit-linear-gradient(top, $math-button-lighter-color, $math-button-hover-color);
             background-image: -moz-linear-gradient(top, $math-button-lighter-color, $math-button-hover-color);

--- a/frontend/src/js/components/modals/Calculator/Calculator.scss
+++ b/frontend/src/js/components/modals/Calculator/Calculator.scss
@@ -11,9 +11,29 @@ $math-button-lighter-color: rgb(255, 245, 223);
 $math-button-darker-color: rgb(255, 245, 132);
 $math-button-hover-color: rgb(222, 210, 83);
 
-.input-container{
-    
+.main-container{
+    display: grid;
+    grid-template-columns: 1fr 4fr;
+    grid-template-rows: 250px 250px;
 }
+.variable-list{
+    grid-column: 1 / 2;
+    grid-row: 1 / 2; 
+}
+.operation-list {
+    grid-column: 1 / 2;
+    grid-row: 2 / 3; 
+}
+.input-container {
+    grid-column: 2 / 3; 
+    grid-row: 1 / 2; 
+}
+.calculator-buttons{
+    grid-column: 2 / 3; 
+    grid-row: 2 / 3; 
+}
+
+
 
 button.calc-button{
     width: 100%;

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -85,10 +85,10 @@ class CalculatorButtons extends React.Component {
                     id="power"
                     className="calc-button advanced"
                     onClick={() => {
-                        this.props.handleOperator("^");
+                        this.props.handleOperator("**");
                     }}
                 >
-                    x^y
+                    x<sup>y</sup>
                 </Button>
 
                 <Button id="unused" className="calc-button" disabled={true} />

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+
+class CalculatorButtons extends React.Component{
+    constructor(props){
+        super(props)
+    }
+
+    render(){
+        return(
+            <div className="calculator-buttons">
+                <div style={{ display: "flex", flexWrap: "nowrap" }}>
+                    <button className="calc-button" disabled="disabled" />
+                    <button className="calc-button numeric">7</button>
+                    <button className="calc-button numeric">8</button>
+                    <button className="calc-button numeric">9</button>
+                    <button className="calc-button math">+</button>
+                </div>
+                <div style={{ display: "flex", flexWrap: "nowrap" }}>
+                    <button className="calc-button save-clear">Clear</button>
+                    <button className="calc-button numeric">4</button>
+                    <button className="calc-button numeric">5</button>
+                    <button className="calc-button numeric">6</button>
+                    <button className="calc-button math">-</button>
+                </div>
+                <div style={{ display: "flex", flexWrap: "nowrap" }}>
+                    <button className="calc-button save-clear">Del</button>
+                    <button className="calc-button numeric">1</button>
+                    <button className="calc-button numeric">2</button>
+                    <button className="calc-button numeric">3</button>
+                    <button className="calc-button math">x</button>
+                </div>
+                <div style={{ display: "flex", flexWrap: "nowrap" }}>
+                    <button className="calc-button save-clear">Enter</button>
+                    <button className="calc-button numeric">0</button>
+                    <button className="calc-button numeric">.</button>
+                    <button className="calc-button numeric">+/-</button>
+                    <button className="calc-button math">/</button>
+                </div>
+            </div>
+        )
+    }
+}
+
+export default CalculatorButtons

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { Button } from "react-bootstrap";
 
 class CalculatorButtons extends React.Component {
     constructor(props) {
@@ -9,35 +10,244 @@ class CalculatorButtons extends React.Component {
     render() {
         /* istanbul ignore next */
         return (
-            /* prettier-ignore */
             <div className="calculator-buttons">
-                <button id="regrid" className="calc-button advanced" onClick={() => {this.props.handleRegrid()}}>Regrid</button>
-                <button id="power" className="calc-button advanced" onClick={() => {this.props.handleOperator("^")}}>x^y</button>
-            
-                <button id="unused" className="calc-button" disabled="disabled" />
-                <button id="seven" className="calc-button numeric" onClick={() => {this.props.handleConstant(7)}}>7</button>
-                <button id="eight" className="calc-button numeric" onClick={() => {this.props.handleConstant(8)}}>8</button>
-                <button id="nine" className="calc-button numeric" onClick={() => {this.props.handleConstant(9)}}>9</button>
-                <button id="divide" className="calc-button math" onClick={() => {this.props.handleOperator("/")}}>/</button>
-            
-                <button id="clear" className="calc-button save-clear" onClick={this.props.handleClear}>Clear</button>
-                <button id="four" className="calc-button numeric" onClick={() => {this.props.handleConstant(4)}}>4</button>
-                <button id="five" className="calc-button numeric" onClick={() => {this.props.handleConstant(5)}}>5</button>
-                <button id="six" className="calc-button numeric" onClick={() => {this.props.handleConstant(6)}}>6</button>
-                <button id="multiply" className="calc-button math" onClick={() => {this.props.handleOperator("*")}}>x</button>
-            
-                <button id="delete" className="calc-button save-clear" onClick={this.props.handleDelete}>Del</button>
-                <button id="one" className="calc-button numeric" onClick={() => {this.props.handleConstant(1)}}>1</button>
-                <button id="two" className="calc-button numeric" onClick={() => {this.props.handleConstant(2)}}>2</button>
-                <button id="three" className="calc-button numeric" onClick={() => {this.props.handleConstant(3)}}>3</button>
-                <button id="subtract" className="calc-button math" onClick={() => {this.props.handleOperator("-")}}>-</button>
-            
-                <button id="enter" className="calc-button save-clear" onClick={this.props.handleEnter}>Enter</button>
-                <button id="zero" className="calc-button numeric" onClick={() => {this.props.handleConstant(0)}}>0</button>
-                <button id="decimal" className="calc-button numeric" onClick={() => {this.props.handleDecimal()}}>.</button>
-                <button id="plusminus" className="calc-button numeric" onClick={() => {this.props.handlePlusMinus()}}>+/-</button>
-                <button id="add" className="calc-button math" onClick={() => {this.props.handleOperator("+")}}>+</button>
-                
+                <div id="regrid" className="dropdown btn-group">
+                    <button
+                        type="button"
+                        className="btn calc-button advanced"
+                        onClick={() => {
+                            this.props.handleOperator("regrid", { tool: "esmf", method: "linear" });
+                        }}
+                    >
+                        Regrid
+                    </button>
+                    <button
+                        type="button"
+                        className="btn dropdown-toggle calc-button advanced"
+                        data-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                    >
+                        <span className="caret" />
+                        <span className="sr-only">Toggle Dropdown</span>
+                    </button>
+                    <ul className="dropdown-menu">
+                        <li>
+                            <a
+                                onClick={() => {
+                                    this.props.handleOperator("regrid", { tool: "esmf", method: "linear" });
+                                }}
+                            >
+                                ESMF - Linear
+                            </a>
+                        </li>
+                        <li>
+                            <a
+                                onClick={() => {
+                                    this.props.handleOperator("regrid", { tool: "esmf", method: "conserve" });
+                                }}
+                            >
+                                ESMF - Conserve
+                            </a>
+                        </li>
+                        <li>
+                            <a
+                                onClick={() => {
+                                    this.props.handleOperator("regrid", { tool: "esmf", method: "patch" });
+                                }}
+                            >
+                                ESMF - Patch
+                            </a>
+                        </li>
+                        <li role="separator" className="divider" />
+                        <li>
+                            <a
+                                onClick={() => {
+                                    this.props.handleOperator("regrid", { tool: "libcf" });
+                                }}
+                            >
+                                LibCF - linear
+                            </a>
+                        </li>
+                        <li role="separator" className="divider" />
+                        <li>
+                            <a
+                                onClick={() => {
+                                    this.props.handleOperator("regrid", { tool: "regrid2" });
+                                }}
+                            >
+                                Regrid2 - old behavior
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <Button
+                    id="power"
+                    className="calc-button advanced"
+                    onClick={() => {
+                        this.props.handleOperator("^");
+                    }}
+                >
+                    x^y
+                </Button>
+
+                <Button id="unused" className="calc-button" disabled={true} />
+                <Button
+                    id="seven"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(7);
+                    }}
+                >
+                    7
+                </Button>
+                <Button
+                    id="eight"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(8);
+                    }}
+                >
+                    8
+                </Button>
+                <Button
+                    id="nine"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(9);
+                    }}
+                >
+                    9
+                </Button>
+                <Button
+                    id="divide"
+                    className="calc-button math"
+                    onClick={() => {
+                        this.props.handleOperator("/");
+                    }}
+                >
+                    /
+                </Button>
+
+                <Button id="clear" className="calc-button save-clear" onClick={this.props.handleClear}>
+                    Clear
+                </Button>
+                <Button
+                    id="four"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(4);
+                    }}
+                >
+                    4
+                </Button>
+                <Button
+                    id="five"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(5);
+                    }}
+                >
+                    5
+                </Button>
+                <Button
+                    id="six"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(6);
+                    }}
+                >
+                    6
+                </Button>
+                <Button
+                    id="multiply"
+                    className="calc-button math"
+                    onClick={() => {
+                        this.props.handleOperator("*");
+                    }}
+                >
+                    x
+                </Button>
+
+                <Button id="delete" className="calc-button save-clear" onClick={this.props.handleDelete}>
+                    Del
+                </Button>
+                <Button
+                    id="one"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(1);
+                    }}
+                >
+                    1
+                </Button>
+                <Button
+                    id="two"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(2);
+                    }}
+                >
+                    2
+                </Button>
+                <Button
+                    id="three"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(3);
+                    }}
+                >
+                    3
+                </Button>
+                <Button
+                    id="subtract"
+                    className="calc-button math"
+                    onClick={() => {
+                        this.props.handleOperator("-");
+                    }}
+                >
+                    -
+                </Button>
+
+                <Button id="enter" className="calc-button save-clear" onClick={this.props.handleEnter}>
+                    Enter
+                </Button>
+                <Button
+                    id="zero"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleConstant(0);
+                    }}
+                >
+                    0
+                </Button>
+                <Button
+                    id="decimal"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handleDecimal();
+                    }}
+                >
+                    .
+                </Button>
+                <Button
+                    id="plusminus"
+                    className="calc-button numeric"
+                    onClick={() => {
+                        this.props.handlePlusMinus();
+                    }}
+                >
+                    +/-
+                </Button>
+                <Button
+                    id="add"
+                    className="calc-button math"
+                    onClick={() => {
+                        this.props.handleOperator("+");
+                    }}
+                >
+                    +
+                </Button>
             </div>
         );
     }
@@ -50,8 +260,7 @@ CalculatorButtons.propTypes = {
     handleEnter: PropTypes.func,
     handleOperator: PropTypes.func,
     handleDecimal: PropTypes.func,
-    handlePlusMinus: PropTypes.func,
-    handleRegrid: PropTypes.func
+    handlePlusMinus: PropTypes.func
 };
 
 export default CalculatorButtons;

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -11,34 +11,33 @@ class CalculatorButtons extends React.Component {
         return (
             /* prettier-ignore */
             <div className="calculator-buttons">
-                <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                    <button className="calc-button" disabled="disabled" />
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(7)}}>7</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(8)}}>8</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(9)}}>9</button>
-                    <button className="calc-button math" onClick={() => {this.props.handleOperator("/")}}>/</button>
-                </div>
-                <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                    <button className="calc-button save-clear" onClick={this.props.handleClear}>Clear</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(4)}}>4</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(5)}}>5</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(6)}}>6</button>
-                    <button className="calc-button math" onClick={() => {this.props.handleOperator("*")}}>x</button>
-                </div>
-                <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                    <button className="calc-button save-clear" onClick={this.props.handleDelete}>Del</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(1)}}>1</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(2)}}>2</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(3)}}>3</button>
-                    <button className="calc-button math" onClick={() => {this.props.handleOperator("-")}}>-</button>
-                </div>
-                <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                    <button className="calc-button save-clear" onClick={this.props.handleEnter}>Enter</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(0)}}>0</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handleDecimal()}}>.</button>
-                    <button className="calc-button numeric" onClick={() => {this.props.handlePlusMinus()}}>+/-</button>
-                    <button className="calc-button math" onClick={() => {this.props.handleOperator("+")}}>+</button>
-                </div>
+                <button id="regrid" className="calc-button advanced" onClick={() => {this.props.handleRegrid()}}>Regrid</button>
+                <button id="power" className="calc-button advanced" onClick={() => {this.props.handleOperator("^")}}>x^y</button>
+            
+                <button id="unused" className="calc-button" disabled="disabled" />
+                <button id="seven" className="calc-button numeric" onClick={() => {this.props.handleConstant(7)}}>7</button>
+                <button id="eight" className="calc-button numeric" onClick={() => {this.props.handleConstant(8)}}>8</button>
+                <button id="nine" className="calc-button numeric" onClick={() => {this.props.handleConstant(9)}}>9</button>
+                <button id="divide" className="calc-button math" onClick={() => {this.props.handleOperator("/")}}>/</button>
+            
+                <button id="clear" className="calc-button save-clear" onClick={this.props.handleClear}>Clear</button>
+                <button id="four" className="calc-button numeric" onClick={() => {this.props.handleConstant(4)}}>4</button>
+                <button id="five" className="calc-button numeric" onClick={() => {this.props.handleConstant(5)}}>5</button>
+                <button id="six" className="calc-button numeric" onClick={() => {this.props.handleConstant(6)}}>6</button>
+                <button id="multiply" className="calc-button math" onClick={() => {this.props.handleOperator("*")}}>x</button>
+            
+                <button id="delete" className="calc-button save-clear" onClick={this.props.handleDelete}>Del</button>
+                <button id="one" className="calc-button numeric" onClick={() => {this.props.handleConstant(1)}}>1</button>
+                <button id="two" className="calc-button numeric" onClick={() => {this.props.handleConstant(2)}}>2</button>
+                <button id="three" className="calc-button numeric" onClick={() => {this.props.handleConstant(3)}}>3</button>
+                <button id="subtract" className="calc-button math" onClick={() => {this.props.handleOperator("-")}}>-</button>
+            
+                <button id="enter" className="calc-button save-clear" onClick={this.props.handleEnter}>Enter</button>
+                <button id="zero" className="calc-button numeric" onClick={() => {this.props.handleConstant(0)}}>0</button>
+                <button id="decimal" className="calc-button numeric" onClick={() => {this.props.handleDecimal()}}>.</button>
+                <button id="plusminus" className="calc-button numeric" onClick={() => {this.props.handlePlusMinus()}}>+/-</button>
+                <button id="add" className="calc-button math" onClick={() => {this.props.handleOperator("+")}}>+</button>
+                
             </div>
         );
     }
@@ -51,7 +50,8 @@ CalculatorButtons.propTypes = {
     handleEnter: PropTypes.func,
     handleOperator: PropTypes.func,
     handleDecimal: PropTypes.func,
-    handlePlusMinus: PropTypes.func
+    handlePlusMinus: PropTypes.func,
+    handleRegrid: PropTypes.func
 };
 
 export default CalculatorButtons;

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -1,44 +1,45 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-class CalculatorButtons extends React.Component{
-    constructor(props){
+class CalculatorButtons extends React.Component {
+    constructor(props) {
         super(props);
     }
 
-    render(){
-        return(
+    render() {
+        return (
+            /* prettier-ignore */
             <div className="calculator-buttons">
                 <div style={{ display: "flex", flexWrap: "nowrap" }}>
                     <button className="calc-button" disabled="disabled" />
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(7)}}>7</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(8)}}>8</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(9)}}>9</button>
-                    <button className="calc-button math" onClick={() => {this.props.handleOperator("+")}}>+</button>
+                    <button className="calc-button math" onClick={() => {this.props.handleOperator("/")}}>/</button>
                 </div>
                 <div style={{ display: "flex", flexWrap: "nowrap" }}>
                     <button className="calc-button save-clear" onClick={this.props.handleClear}>Clear</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(4)}}>4</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(5)}}>5</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(6)}}>6</button>
-                    <button className="calc-button math" onClick={() => {this.props.handleOperator("-")}}>-</button>
+                    <button className="calc-button math" onClick={() => {this.props.handleOperator("*")}}>x</button>
                 </div>
                 <div style={{ display: "flex", flexWrap: "nowrap" }}>
                     <button className="calc-button save-clear" onClick={this.props.handleDelete}>Del</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(1)}}>1</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(2)}}>2</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(3)}}>3</button>
-                    <button className="calc-button math" onClick={() => {this.props.handleOperator("*")}}>x</button>
+                    <button className="calc-button math" onClick={() => {this.props.handleOperator("-")}}>-</button>
                 </div>
                 <div style={{ display: "flex", flexWrap: "nowrap" }}>
                     <button className="calc-button save-clear" onClick={this.props.handleEnter}>Enter</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(0)}}>0</button>
                     <button className="calc-button numeric">.</button>
                     <button className="calc-button numeric">+/-</button>
-                    <button className="calc-button math" onClick={() => {this.props.handleOperator("/")}}>/</button>
+                    <button className="calc-button math" onClick={() => {this.props.handleOperator("+")}}>+</button>
                 </div>
             </div>
-        )
+        );
     }
 }
 
@@ -47,7 +48,7 @@ CalculatorButtons.propTypes = {
     handleClear: PropTypes.func,
     handleDelete: PropTypes.func,
     handleEnter: PropTypes.func,
-    handleOperator: PropTypes.func,
+    handleOperator: PropTypes.func
 };
 
 export default CalculatorButtons;

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -7,6 +7,7 @@ class CalculatorButtons extends React.Component {
     }
 
     render() {
+        /* istanbul ignore next */
         return (
             /* prettier-ignore */
             <div className="calculator-buttons">

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -36,7 +36,7 @@ class CalculatorButtons extends React.Component {
                     <button className="calc-button save-clear" onClick={this.props.handleEnter}>Enter</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(0)}}>0</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleDecimal()}}>.</button>
-                    <button className="calc-button numeric">+/-</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handlePlusMinus()}}>+/-</button>
                     <button className="calc-button math" onClick={() => {this.props.handleOperator("+")}}>+</button>
                 </div>
             </div>
@@ -50,7 +50,8 @@ CalculatorButtons.propTypes = {
     handleDelete: PropTypes.func,
     handleEnter: PropTypes.func,
     handleOperator: PropTypes.func,
-    handleDecimal: PropTypes.func
+    handleDecimal: PropTypes.func,
+    handlePlusMinus: PropTypes.func
 };
 
 export default CalculatorButtons;

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -35,7 +35,7 @@ class CalculatorButtons extends React.Component {
                 <div style={{ display: "flex", flexWrap: "nowrap" }}>
                     <button className="calc-button save-clear" onClick={this.props.handleEnter}>Enter</button>
                     <button className="calc-button numeric" onClick={() => {this.props.handleConstant(0)}}>0</button>
-                    <button className="calc-button numeric">.</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleDecimal()}}>.</button>
                     <button className="calc-button numeric">+/-</button>
                     <button className="calc-button math" onClick={() => {this.props.handleOperator("+")}}>+</button>
                 </div>
@@ -49,7 +49,8 @@ CalculatorButtons.propTypes = {
     handleClear: PropTypes.func,
     handleDelete: PropTypes.func,
     handleEnter: PropTypes.func,
-    handleOperator: PropTypes.func
+    handleOperator: PropTypes.func,
+    handleDecimal: PropTypes.func
 };
 
 export default CalculatorButtons;

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class CalculatorButtons extends React.PureComponent{
+class CalculatorButtons extends React.Component{
     constructor(props){
         super(props);
     }

--- a/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
+++ b/frontend/src/js/components/modals/Calculator/CalculatorButtons.jsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 
-class CalculatorButtons extends React.Component{
+class CalculatorButtons extends React.PureComponent{
     constructor(props){
-        super(props)
+        super(props);
     }
 
     render(){
@@ -10,35 +11,43 @@ class CalculatorButtons extends React.Component{
             <div className="calculator-buttons">
                 <div style={{ display: "flex", flexWrap: "nowrap" }}>
                     <button className="calc-button" disabled="disabled" />
-                    <button className="calc-button numeric">7</button>
-                    <button className="calc-button numeric">8</button>
-                    <button className="calc-button numeric">9</button>
-                    <button className="calc-button math">+</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(7)}}>7</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(8)}}>8</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(9)}}>9</button>
+                    <button className="calc-button math" onClick={() => {this.props.handleOperator("+")}}>+</button>
                 </div>
                 <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                    <button className="calc-button save-clear">Clear</button>
-                    <button className="calc-button numeric">4</button>
-                    <button className="calc-button numeric">5</button>
-                    <button className="calc-button numeric">6</button>
-                    <button className="calc-button math">-</button>
+                    <button className="calc-button save-clear" onClick={this.props.handleClear}>Clear</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(4)}}>4</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(5)}}>5</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(6)}}>6</button>
+                    <button className="calc-button math" onClick={() => {this.props.handleOperator("-")}}>-</button>
                 </div>
                 <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                    <button className="calc-button save-clear">Del</button>
-                    <button className="calc-button numeric">1</button>
-                    <button className="calc-button numeric">2</button>
-                    <button className="calc-button numeric">3</button>
-                    <button className="calc-button math">x</button>
+                    <button className="calc-button save-clear" onClick={this.props.handleDelete}>Del</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(1)}}>1</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(2)}}>2</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(3)}}>3</button>
+                    <button className="calc-button math" onClick={() => {this.props.handleOperator("*")}}>x</button>
                 </div>
                 <div style={{ display: "flex", flexWrap: "nowrap" }}>
-                    <button className="calc-button save-clear">Enter</button>
-                    <button className="calc-button numeric">0</button>
+                    <button className="calc-button save-clear" onClick={this.props.handleEnter}>Enter</button>
+                    <button className="calc-button numeric" onClick={() => {this.props.handleConstant(0)}}>0</button>
                     <button className="calc-button numeric">.</button>
                     <button className="calc-button numeric">+/-</button>
-                    <button className="calc-button math">/</button>
+                    <button className="calc-button math" onClick={() => {this.props.handleOperator("/")}}>/</button>
                 </div>
             </div>
         )
     }
 }
 
-export default CalculatorButtons
+CalculatorButtons.propTypes = {
+    handleConstant: PropTypes.func,
+    handleClear: PropTypes.func,
+    handleDelete: PropTypes.func,
+    handleEnter: PropTypes.func,
+    handleOperator: PropTypes.func,
+};
+
+export default CalculatorButtons;

--- a/frontend/src/js/components/modals/Calculator/InputArea.jsx
+++ b/frontend/src/js/components/modals/Calculator/InputArea.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+class InputArea extends React.Component {
+    constructor(props){
+        super(props)
+    }
+
+    render(){
+        return (
+            <div className="input-area">
+                <div className="input-wrapper">
+                    <input className="new-variable-name" type="text" placeholder="test"/>
+                    <span className="equals"> = </span>
+                    <input className="calculation" type="text" value="testing" disabled />
+                </div>
+            </div>
+        )
+    }
+}
+
+export default InputArea

--- a/frontend/src/js/components/modals/Calculator/InputArea.jsx
+++ b/frontend/src/js/components/modals/Calculator/InputArea.jsx
@@ -1,21 +1,64 @@
-import React from 'react'
+import React from "react";
+import PropTypes from "prop-types";
+import { DropTarget } from "react-dnd";
+import DragAndDropTypes from "../../../constants/DragAndDropTypes.js";
+
+const spec = {
+    drop(props, monitor /* component */) {
+        const variable = monitor.getItem();
+        if (monitor.getItemType() === DragAndDropTypes.VAR) props.onDrop(variable);
+    },
+    hover(/* props, monitor, component */) {},
+    canDrop(/* props, monitor */) {
+        // console.log("Printing canDrop props and monitor")
+        // console.log(props)
+        // console.log(monitor)
+        return true;
+    }
+};
+
+const collect = function(connect, monitor) {
+    return {
+        connectDropTarget: connect.dropTarget(),
+        is_over: monitor.isOver(),
+        can_drop: monitor.canDrop()
+    };
+};
 
 class InputArea extends React.Component {
-    constructor(props){
-        super(props)
+    constructor(props) {
+        super(props);
     }
 
-    render(){
-        return (
-            <div className="input-area">
+    render() {
+        const { connectDropTarget, can_drop, is_over } = this.props;
+        let drop_class = "";
+        if (is_over && can_drop) {
+            drop_class = "drop-success";
+        } else if (can_drop) {
+            drop_class = "drop-hint";
+        }
+
+        return connectDropTarget(
+            <div className={`input-area ${drop_class}`}>
                 <div className="input-wrapper">
-                    <input className="new-variable-name" type="text" placeholder="test"/>
+                    <input className="new-variable-name" type="text" placeholder={this.props.new_variable_placeholder} />
                     <span className="equals"> = </span>
-                    <input className="calculation" type="text" value="testing" disabled />
+                    <input className="calculation" type="text" value={this.props.calculation} disabled />
                 </div>
             </div>
-        )
+        );
     }
 }
 
-export default InputArea
+InputArea.propTypes = {
+    new_variable_name: PropTypes.string,
+    new_variable_placeholder: PropTypes.string,
+    calculation: PropTypes.string,
+    connectDropTarget: PropTypes.func,
+    onDrop: PropTypes.func,
+    can_drop: PropTypes.bool, // prop added by react-dnd
+    is_over: PropTypes.bool // prop added by react-dnd
+};
+
+export default DropTarget(DragAndDropTypes.VAR, spec, collect)(InputArea);

--- a/frontend/src/js/components/modals/Calculator/InputArea.jsx
+++ b/frontend/src/js/components/modals/Calculator/InputArea.jsx
@@ -28,15 +28,15 @@ const collect = function(connect, monitor) {
 class InputArea extends React.Component {
     constructor(props) {
         super(props);
-        this.handleBlur = this.handleBlur.bind(this)
-        this.handleFocus = this.handleFocus.bind(this)
+        this.handleBlur = this.handleBlur.bind(this);
+        this.handleFocus = this.handleFocus.bind(this);
     }
 
-    handleFocus(){
+    handleFocus() {
         this.props.setFocus(true);
     }
 
-    handleBlur(){
+    handleBlur() {
         this.props.setFocus(false);
     }
 
@@ -58,7 +58,7 @@ class InputArea extends React.Component {
                     onBlur={this.handleBlur}
                     value={this.props.new_variable_name}
                     onChange={this.props.handleNewVariableName}
-                    placeholder={this.props.new_variable_placeholder ? this.props.new_variable_placeholder : "New_Variable_Name"}
+                    placeholder={this.props.new_variable_placeholder}
                 />
                 <small id="new-variable-name-help-text" className="form-text text-muted">
                     Enter a new variable name to save the calculation to.
@@ -85,6 +85,10 @@ InputArea.propTypes = {
     onDrop: PropTypes.func,
     can_drop: PropTypes.bool, // prop added by react-dnd
     is_over: PropTypes.bool // prop added by react-dnd
+};
+
+InputArea.defaultProps = {
+    new_variable_placeholder: ""
 };
 
 export default DropTarget(DragAndDropTypes.VAR, spec, collect)(InputArea);

--- a/frontend/src/js/components/modals/Calculator/InputArea.jsx
+++ b/frontend/src/js/components/modals/Calculator/InputArea.jsx
@@ -28,6 +28,16 @@ const collect = function(connect, monitor) {
 class InputArea extends React.Component {
     constructor(props) {
         super(props);
+        this.handleBlur = this.handleBlur.bind(this)
+        this.handleFocus = this.handleFocus.bind(this)
+    }
+
+    handleFocus(){
+        this.props.setFocus(true);
+    }
+
+    handleBlur(){
+        this.props.setFocus(false);
     }
 
     render() {
@@ -44,10 +54,14 @@ class InputArea extends React.Component {
                 <input
                     id="new-variable-name"
                     type="text"
+                    onFocus={this.handleFocus}
+                    onBlur={this.handleBlur}
+                    value={this.props.new_variable_name}
+                    onChange={this.props.handleNewVariableName}
                     placeholder={this.props.new_variable_placeholder ? this.props.new_variable_placeholder : "New_Variable_Name"}
                 />
                 <small id="new-variable-name-help-text" className="form-text text-muted">
-                    New variable name
+                    Enter a new variable name to save the calculation to.
                 </small>
                 <div id="assignment">
                     <span className="glyphicon glyphicon-arrow-left" />
@@ -64,7 +78,9 @@ class InputArea extends React.Component {
 InputArea.propTypes = {
     new_variable_name: PropTypes.string,
     new_variable_placeholder: PropTypes.string,
+    handleNewVariableName: PropTypes.func,
     calculation: PropTypes.string,
+    setFocus: PropTypes.func,
     connectDropTarget: PropTypes.func,
     onDrop: PropTypes.func,
     can_drop: PropTypes.bool, // prop added by react-dnd

--- a/frontend/src/js/components/modals/Calculator/InputArea.jsx
+++ b/frontend/src/js/components/modals/Calculator/InputArea.jsx
@@ -41,11 +41,21 @@ class InputArea extends React.Component {
 
         return connectDropTarget(
             <div className={`input-area ${drop_class}`}>
-                <div className="input-wrapper">
-                    <input className="new-variable-name" type="text" placeholder={this.props.new_variable_placeholder} />
-                    <span className="equals"> = </span>
-                    <input className="calculation" type="text" value={this.props.calculation} disabled />
+                <input
+                    id="new-variable-name"
+                    type="text"
+                    placeholder={this.props.new_variable_placeholder ? this.props.new_variable_placeholder : "New_Variable_Name"}
+                />
+                <small id="new-variable-name-help-text" className="form-text text-muted">
+                    New variable name
+                </small>
+                <div id="assignment">
+                    <span className="glyphicon glyphicon-arrow-left" />
                 </div>
+                <input id="calculation" type="text" value={this.props.calculation} disabled />
+                <small id="calculation-help-text" className="form-text text-muted">
+                    Construct a calculation by dragging variables here.
+                </small>
             </div>
         );
     }

--- a/frontend/src/js/components/modals/Calculator/InputArea.jsx
+++ b/frontend/src/js/components/modals/Calculator/InputArea.jsx
@@ -10,9 +10,6 @@ const spec = {
     },
     hover(/* props, monitor, component */) {},
     canDrop(/* props, monitor */) {
-        // console.log("Printing canDrop props and monitor")
-        // console.log(props)
-        // console.log(monitor)
         return true;
     }
 };

--- a/frontend/src/js/components/modals/Calculator/VariableList.jsx
+++ b/frontend/src/js/components/modals/Calculator/VariableList.jsx
@@ -30,7 +30,7 @@ function VariableItem(props) {
 
 const DraggableVariable = DragSource(DragAndDropTypes.VAR, varSource, collect)(VariableItem);
 
-class VarList extends Component {
+class VariableList extends Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -64,11 +64,11 @@ class VarList extends Component {
     }
 }
 
-VarList.propTypes = {
+VariableList.propTypes = {
     cachedFiles: PropTypes.object,
     loadVariables: PropTypes.func,
     variables: PropTypes.arrayOf(PropTypes.string),
     removeVariable: PropTypes.func
 };
 
-export default VarList;
+export default VariableList;

--- a/frontend/src/js/components/modals/Calculator/VariableList.jsx
+++ b/frontend/src/js/components/modals/Calculator/VariableList.jsx
@@ -1,19 +1,17 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import AddEditRemoveNav from '../../AddEditRemoveNav/AddEditRemoveNav.jsx'
-import { DragSource } from 'react-dnd'
-import DragAndDropTypes from '../../../constants/DragAndDropTypes.js'
-import { toast } from "react-toastify"
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { DragSource } from "react-dnd";
+import DragAndDropTypes from "../../../constants/DragAndDropTypes.js";
 
-import './Calculator.scss'
+import "./Calculator.scss";
 
 var varSource = {
-    beginDrag: function (props) {
+    beginDrag: function(props) {
         return {
-            'variable': props.variable,
+            name: props.variable
         };
     }
-}
+};
 
 function collect(connect, monitor) {
     return {
@@ -24,7 +22,7 @@ function collect(connect, monitor) {
 
 function VariableItem(props) {
     return props.connectDragSource(
-        <li className={props.active ? "active" : ""} >
+        <li>
             <a>{props.variable}</a>
         </li>
     );
@@ -33,41 +31,36 @@ function VariableItem(props) {
 const DraggableVariable = DragSource(DragAndDropTypes.VAR, varSource, collect)(VariableItem);
 
 class VarList extends Component {
-    constructor(props){
-        super(props)
+    constructor(props) {
+        super(props);
         this.state = {
             showFile: false,
             showEdit: false
-        }
-        this.removeVariable = this.removeVariable.bind(this)
+        };
+        this.removeVariable = this.removeVariable.bind(this);
     }
 
     removeVariable() {
-        this.props.removeVariable()
+        this.props.removeVariable();
     }
 
     render() {
         return (
-            <div className='left-side-list scroll-area-list-parent variable-list effect6'>
+            <div className="left-side-list scroll-area-list-parent variable-list effect6">
                 <nav className="navbar navbar-default">
                     <div className="container-fluid">
-                        <p className='side-nav-header'>Variables</p>
+                        <p className="side-nav-header">Variables</p>
                     </div>
                 </nav>
-                <div className='scroll-area'>
-                    <ul id='calc-variable-list' className='no-bullets left-list'>
-                        {this.props.variables.map((value) => {
-                            return (
-                                <DraggableVariable 
-                                    key={value}
-                                    variable={value}
-                                />
-                            )
+                <div className="scroll-area">
+                    <ul id="calc-variable-list" className="no-bullets left-list">
+                        {this.props.variables.map(value => {
+                            return <DraggableVariable key={value} variable={value} />;
                         })}
                     </ul>
                 </div>
             </div>
-        )
+        );
     }
 }
 
@@ -75,7 +68,7 @@ VarList.propTypes = {
     cachedFiles: PropTypes.object,
     loadVariables: PropTypes.func,
     variables: PropTypes.arrayOf(PropTypes.string),
-    removeVariable: PropTypes.func,
-}
+    removeVariable: PropTypes.func
+};
 
 export default VarList;

--- a/frontend/src/js/components/modals/Calculator/VariableList.jsx
+++ b/frontend/src/js/components/modals/Calculator/VariableList.jsx
@@ -1,0 +1,81 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import AddEditRemoveNav from '../../AddEditRemoveNav/AddEditRemoveNav.jsx'
+import { DragSource } from 'react-dnd'
+import DragAndDropTypes from '../../../constants/DragAndDropTypes.js'
+import { toast } from "react-toastify"
+
+import './Calculator.scss'
+
+var varSource = {
+    beginDrag: function (props) {
+        return {
+            'variable': props.variable,
+        };
+    }
+}
+
+function collect(connect, monitor) {
+    return {
+        connectDragSource: connect.dragSource(),
+        isDragging: monitor.isDragging()
+    };
+}
+
+function VariableItem(props) {
+    return props.connectDragSource(
+        <li className={props.active ? "active" : ""} >
+            <a>{props.variable}</a>
+        </li>
+    );
+}
+
+const DraggableVariable = DragSource(DragAndDropTypes.VAR, varSource, collect)(VariableItem);
+
+class VarList extends Component {
+    constructor(props){
+        super(props)
+        this.state = {
+            showFile: false,
+            showEdit: false
+        }
+        this.removeVariable = this.removeVariable.bind(this)
+    }
+
+    removeVariable() {
+        this.props.removeVariable()
+    }
+
+    render() {
+        return (
+            <div className='left-side-list scroll-area-list-parent variable-list effect6'>
+                <nav className="navbar navbar-default">
+                    <div className="container-fluid">
+                        <p className='side-nav-header'>Variables</p>
+                    </div>
+                </nav>
+                <div className='scroll-area'>
+                    <ul id='calc-variable-list' className='no-bullets left-list'>
+                        {this.props.variables.map((value) => {
+                            return (
+                                <DraggableVariable 
+                                    key={value}
+                                    variable={value}
+                                />
+                            )
+                        })}
+                    </ul>
+                </div>
+            </div>
+        )
+    }
+}
+
+VarList.propTypes = {
+    cachedFiles: PropTypes.object,
+    loadVariables: PropTypes.func,
+    variables: PropTypes.arrayOf(PropTypes.string),
+    removeVariable: PropTypes.func,
+}
+
+export default VarList;

--- a/frontend/src/js/components/modals/EditVariable.jsx
+++ b/frontend/src/js/components/modals/EditVariable.jsx
@@ -33,7 +33,10 @@ class EditVariable extends Component {
     }
 
     getVariableInfo() {
-        let spec = this.props.variables[this.props.active_variable].path;
+        let spec = {
+            file_name: this.props.variables[this.props.active_variable].path,
+            var_name: this.props.variables[this.props.active_variable].cdms_var_name
+        };
         if (this.props.variables[this.props.active_variable].json) {
             spec = {
                 json: this.props.variables[this.props.active_variable].json
@@ -45,7 +48,7 @@ class EditVariable extends Component {
                 selectedVariable = variablesAxes[0];
                 dimension = $.extend(true, [], this.props.variables[this.props.active_variable].dimension);
                 if (dimension.length === 0) {
-                    dimension = Object.keys(variablesAxes[1]).map(name => {
+                    dimension = variablesAxes[0].axisList.map(name => {
                         return { axisName: name };
                     });
                 }
@@ -55,6 +58,7 @@ class EditVariable extends Component {
                 this.setState({
                     selectedVariable,
                     variablesAxes,
+                    axisList: selectedVariable.axisList,
                     dimension
                 });
             });
@@ -84,16 +88,13 @@ class EditVariable extends Component {
     }
 
     save() {
-        this.props.updateVariable(this.props.active_variable, this.state.dimension, this.state.axis_transforms);
+        this.props.updateVariable(this.props.active_variable, this.state.axisList, this.state.dimension, this.state.axis_transforms);
         this.props.onTryClose();
     }
 
     render() {
         let slider_values = {};
-        let dimensions =
-            this.props.variables[this.props.active_variable].dimension.length > 0
-                ? this.props.variables[this.props.active_variable].dimension
-                : this.state.dimension;
+        let dimensions = this.state.dimension && this.state.dimension.length > 0 ? this.state.dimension : [];
         if (dimensions) {
             for (let dimension of dimensions) {
                 if (dimension.values) {
@@ -200,7 +201,12 @@ var DimensionContainer = props => {
                     </div>
                 )}
                 <div className="right-content">
-                    <DimensionSlider {...props.axis} onChange={props.handleDimensionValueChange} />
+                    <DimensionSlider
+                        {...props.axis}
+                        low_value={props.low_value}
+                        high_value={props.high_value}
+                        onChange={props.handleDimensionValueChange}
+                    />
                 </div>
                 <AxisTransform axis_name={props.axis.name} axis_transform={props.axis_transform} handleAxisTransform={props.handleAxisTransform} />
             </div>
@@ -263,8 +269,8 @@ var DimensionDnDContainer = _.flow(
 
 const mapDispatchToProps = dispatch => {
     return {
-        updateVariable: (name, dimensions, transforms) => {
-            dispatch(Actions.updateVariable(name, dimensions, transforms));
+        updateVariable: (name, axis_list, dimensions, transforms) => {
+            dispatch(Actions.updateVariable(name, axis_list, dimensions, transforms));
         }
     };
 };

--- a/frontend/src/js/components/modals/EditVariable.jsx
+++ b/frontend/src/js/components/modals/EditVariable.jsx
@@ -42,19 +42,16 @@ class EditVariable extends Component {
         try {
             return vcs.variable(spec).then(variablesAxes => {
                 let selectedVariable, dimension;
-                debugger;
-                // if (variablesAxes[0]) {
-                // it's a variablevar
                 selectedVariable = variablesAxes[0];
                 dimension = $.extend(true, [], this.props.variables[this.props.active_variable].dimension);
+                if (dimension.length === 0) {
+                    dimension = Object.keys(variablesAxes[1]).map(name => {
+                        return { axisName: name };
+                    });
+                }
                 if (this.props.variables[this.props.active_variable].json) {
                     selectedVariable.json = this.props.variables[this.props.active_variable].json;
                 }
-                // } else {
-                //     // it's an axis
-                //     selectedVariable = variablesAxes[1][this.props.active_variable];
-                //     dimension = { axisName: this.props.active_variable };
-                // }
                 this.setState({
                     selectedVariable,
                     variablesAxes,
@@ -93,17 +90,23 @@ class EditVariable extends Component {
 
     render() {
         let slider_values = {};
-        for (let dimension of this.props.variables[this.props.active_variable].dimension) {
-            if (dimension.values) {
-                slider_values[dimension.axisName] = {
-                    range: dimension.values.range,
-                    stride: dimension.stride
-                };
-            } else {
-                slider_values[dimension.axisName] = {
-                    range: [undefined, undefined],
-                    stride: undefined
-                };
+        let dimensions =
+            this.props.variables[this.props.active_variable].dimension.length > 0
+                ? this.props.variables[this.props.active_variable].dimension
+                : this.state.dimension;
+        if (dimensions) {
+            for (let dimension of dimensions) {
+                if (dimension.values) {
+                    slider_values[dimension.axisName] = {
+                        range: dimension.values.range,
+                        stride: dimension.stride
+                    };
+                } else {
+                    slider_values[dimension.axisName] = {
+                        range: [undefined, undefined],
+                        stride: undefined
+                    };
+                }
             }
         }
         return (
@@ -120,7 +123,7 @@ class EditVariable extends Component {
                                 </Col>
                             </Row>
                             {/* If is a variable */}
-                            {this.state.dimension &&
+                            {this.state.dimension.length > 0 &&
                                 this.state.dimension.map(dimension => dimension.axisName).map((axisName, i) => {
                                     let axis = this.state.variablesAxes[1][axisName];
                                     return (

--- a/frontend/src/js/constants/Actions.js
+++ b/frontend/src/js/constants/Actions.js
@@ -180,13 +180,14 @@ var Actions = {
             var_list: var_list
         };
     },
-    updateVariable(name, dimensions, transforms) {
+    updateVariable(name, axis_list, dimensions, transforms) {
         if (!transforms) {
             transforms = {};
         }
         return {
             type: "UPDATE_VARIABLE",
             name: name,
+            axis_list: axis_list,
             dimensions: dimensions,
             transforms: transforms
         };

--- a/frontend/src/js/constants/Actions.js
+++ b/frontend/src/js/constants/Actions.js
@@ -1,195 +1,195 @@
 var Actions = {
     rowCountChanged(count) {
         return {
-            type: 'ROW_COUNT_CHANGED',
+            type: "ROW_COUNT_CHANGED",
             count: count
-        }
+        };
     },
     colCountChanged(count) {
         return {
-            type: 'COL_COUNT_CHANGED',
-            count: count,
-        }
+            type: "COL_COUNT_CHANGED",
+            count: count
+        };
     },
     addSheet() {
         return {
-            type: 'ADD_SHEET'
-        }
+            type: "ADD_SHEET"
+        };
     },
     removeSheet(index) {
         return {
-            type: 'REMOVE_SHEET',
+            type: "REMOVE_SHEET",
             sheet_index: index
-        }
+        };
     },
     changeCurSheetIndex(index) {
         return {
-            type: 'CHANGE_CUR_SHEET_INDEX',
+            type: "CHANGE_CUR_SHEET_INDEX",
             index: index
-        }
+        };
     },
     changePlot(value) {
         return {
-            type: 'CHANGE_PLOT',
+            type: "CHANGE_PLOT",
             value: value
-        }
+        };
     },
     changePlotVar(var_being_changed, value) {
         return {
-            type: 'CHANGE_PLOT_VAR',
+            type: "CHANGE_PLOT_VAR",
             var_being_changed: var_being_changed,
             value: value
-        }
+        };
     },
     changePlotGM(parent, value) {
         var obj = {
-            type: 'CHANGE_PLOT_GM',
-        }
+            type: "CHANGE_PLOT_GM"
+        };
         if (parent) {
-            obj.graphics_method_parent = value
+            obj.graphics_method_parent = value;
         } else {
-            obj.graphics_method = value
+            obj.graphics_method = value;
         }
         return obj;
     },
     changePlotTemplate(value) {
         return {
-            type: 'CHANGE_PLOT_TEMPLATE',
+            type: "CHANGE_PLOT_TEMPLATE",
             value: value
-        }
+        };
     },
     initializeTemplateValues(templates) {
         return {
-            type: 'INITIALIZE_TEMPLATE_VALUES',
+            type: "INITIALIZE_TEMPLATE_VALUES",
             templates: templates
-        }
+        };
     },
     initializeGraphicsMethodsValues(gm) {
         return {
-            type: 'INITIALIZE_GRAPHICS_METHODS_VALUES',
+            type: "INITIALIZE_GRAPHICS_METHODS_VALUES",
             graphics_methods: gm
-        }
+        };
     },
-    selectCell(cell_id){
+    selectCell(cell_id) {
         return {
-            type: 'SELECT_CELL',
+            type: "SELECT_CELL",
             cell_id: cell_id
-        }
+        };
     },
-    deselectCell(){
+    deselectCell() {
         return {
-            type: 'DESELECT_CELL',
-        }
+            type: "DESELECT_CELL"
+        };
     },
     updateSelectedCells(selected_cells) {
         return {
-            type: 'UPDATE_SELECTED_CELLS',
+            type: "UPDATE_SELECTED_CELLS",
             selected_cells: selected_cells
-        }
+        };
     },
     moveColumn(dragged_index, dropped_index, position) {
         return {
-            type: 'MOVE_COLUMN',
+            type: "MOVE_COLUMN",
             dragged_index: dragged_index,
             dropped_index: dropped_index,
             position: position
-        }
+        };
     },
     moveRow(dragged_index, dropped_index, position) {
         return {
-            type: 'MOVE_ROW',
+            type: "MOVE_ROW",
             dragged_index: dragged_index,
             dropped_index: dropped_index,
             position: position
-        }
+        };
     },
-    clearCell(row, col){
-        return({
-            type: 'CLEAR_CELL',
+    clearCell(row, col) {
+        return {
+            type: "CLEAR_CELL",
             row: row,
-            col: col,
-        })
+            col: col
+        };
     },
     addPlot(variable, graphics_method_parent, graphics_method, template, row, col) {
         return {
-            type: 'ADD_PLOT',
+            type: "ADD_PLOT",
             variable: variable,
             graphics_method_parent: graphics_method_parent,
             graphics_method: graphics_method,
             template: template,
             row: row,
             col: col
-        }
+        };
     },
-    deletePlot(row, col, index){
+    deletePlot(row, col, index) {
         return {
-            type: 'DELETE_PLOT',
+            type: "DELETE_PLOT",
             row: row,
             col: col,
             index: index
-        }
+        };
     },
     swapVariableInPlot(value, row, col, plot_index, var_being_changed) {
         return {
-            type: 'CHANGE_PLOT_VAR',
+            type: "CHANGE_PLOT_VAR",
             value: value,
             row: row,
             col: col,
             plot_index: plot_index,
             var_being_changed: var_being_changed
-        }
+        };
     },
-    deleteVariableInPlot(row, col, plot_index, var_index){
-        return{
-            type: 'DELETE_PLOT_VAR',
+    deleteVariableInPlot(row, col, plot_index, var_index) {
+        return {
+            type: "DELETE_PLOT_VAR",
             row: row,
             col: col,
             plot_index: plot_index,
             var_index: var_index
-        }
+        };
     },
     swapGraphicsMethodInPlot(graphics_method_parent, graphics_method, row, col, plot_index) {
         return {
-            type: 'CHANGE_PLOT_GM',
+            type: "CHANGE_PLOT_GM",
             graphics_method_parent: graphics_method_parent,
             graphics_method: graphics_method,
             row: row,
             col: col,
             plot_index: plot_index
-        }
+        };
     },
     swapTemplateInPlot(value, row, col, plot_index) {
         return {
-            type: 'CHANGE_PLOT_TEMPLATE',
+            type: "CHANGE_PLOT_TEMPLATE",
             value: value,
             row: row,
             col: col,
             plot_index: plot_index
-        }
+        };
     },
     shiftSheet(old_position, new_position) {
         return {
-            type: 'SHIFT_SHEET',
+            type: "SHIFT_SHEET",
             old_position: old_position,
             new_position: new_position
-        }
+        };
     },
     loadVariables(var_list) {
         return {
-            type: 'LOAD_VARIABLES',
+            type: "LOAD_VARIABLES",
             var_list: var_list
-        }
+        };
     },
-    updateVariable(name, dimensions, transforms){
-        if(!transforms){
-            transforms = {}
+    updateVariable(name, dimensions, transforms) {
+        if (!transforms) {
+            transforms = {};
         }
         return {
-            type: 'UPDATE_VARIABLE',
+            type: "UPDATE_VARIABLE",
             name: name,
             dimensions: dimensions,
-            transforms: transforms,
-        }
+            transforms: transforms
+        };
     },
     createGraphicsMethod(name, gm_type, base_method) {
         return {
@@ -197,92 +197,93 @@ var Actions = {
             name: name,
             gm_type: gm_type,
             base_method: base_method
-        }
+        };
     },
     selectGraphicsMethod(type, method) {
         return {
             type: "SELECT_GRAPHICS_METHOD",
             gm_type: type,
             method: method
-        }
+        };
     },
     updateGraphicsMethod(graphics_method) {
         return {
-            type: 'UPDATE_GRAPHICS_METHOD',
+            type: "UPDATE_GRAPHICS_METHOD",
             graphics_method
-        }
+        };
     },
     removeGraphicsMethod(gm_type, name) {
         return {
-            type: 'REMOVE_GRAPHICS_METHOD',
+            type: "REMOVE_GRAPHICS_METHOD",
             gm_type: gm_type,
             name: name
-        }
+        };
     },
     initializeColormaps(colormaps) {
         return {
-            type: 'INITIALIZE_COLORMAPS',
+            type: "INITIALIZE_COLORMAPS",
             colormaps: colormaps
-        }
+        };
     },
     initializeDefaultMethods(defaults) {
         return {
-            type: 'INITIALIZE_DEFAULT_METHODS',
+            type: "INITIALIZE_DEFAULT_METHODS",
             defaultmethods: defaults
-        }
+        };
     },
-    selectTemplate(name){
+    selectTemplate(name) {
         return {
-            type: 'SELECT_TEMPLATE',
-            selected_template: name,
-        }
+            type: "SELECT_TEMPLATE",
+            selected_template: name
+        };
     },
     createTemplate(name) {
         return {
-            type: 'CREATE_TEMPLATE',
-            name: name,
-        }
+            type: "CREATE_TEMPLATE",
+            name: name
+        };
     },
     removeTemplate(name) {
         return {
-            type: 'REMOVE_TEMPLATE',
-            name: name,
-        }
+            type: "REMOVE_TEMPLATE",
+            name: name
+        };
     },
     updateTemplate(template) {
         return {
-            type: 'UPDATE_TEMPLATE',
+            type: "UPDATE_TEMPLATE",
             template: template
-        }
+        };
     },
     saveColormap(colormap) {
         return {
-            type: 'SAVE_COLORMAP',
-            colormap: colormap,
-        }
+            type: "SAVE_COLORMAP",
+            colormap: colormap
+        };
     },
     deleteColormap(name) {
         return {
-            type: 'DELETE_COLORMAP',
-            name: name,
-        }
+            type: "DELETE_COLORMAP",
+            name: name
+        };
     },
-    removeVariable(name) { // Removes variable from list of loaded variables (left side bar)
+    removeVariable(name) {
+        // Removes variable from list of loaded variables (left side bar)
         return {
-            type: 'REMOVE_VARIABLE',
-            name: name,
-        }
+            type: "REMOVE_VARIABLE",
+            name: name
+        };
     },
-    setRecentLocalPath(path){
+    setRecentLocalPath(path) {
         // Used with the file explorer and file tab
         // The file tab passes this value to the file explorer
         // The file explorer will open the path it is given
         // This makes it so that a user doesnt have to navigate to the same place over and over
         return {
-            type: 'SET_RECENT_LOCAL_PATH',
-            path: path,
-        }
+            type: "SET_RECENT_LOCAL_PATH",
+            path: path
+        };
     }
-}
+};
 
 export default Actions;

--- a/frontend/src/js/constants/Constants.js
+++ b/frontend/src/js/constants/Constants.js
@@ -1,6 +1,6 @@
 const ONE_VAR_PLOTS = ["boxfill", "isofill", "isoline"]; // meshfill can be either 1 or 2
 const TWO_VAR_PLOTS = ["vector", "3d_vector", "streamline"];
-const UNARY_OPERATORS = [];
+const UNARY_OPERATORS = ["-", "~", "not"];
 const BINARY_OPERATORS = ["+", "-", "^", "/", ">>", "<<", "%", "*", "**", "|", "&", ">", "<", ">=", "<=", "!=", "=="];
 
 const JOYRIDE_STEPS = [

--- a/frontend/src/js/constants/Constants.js
+++ b/frontend/src/js/constants/Constants.js
@@ -1,34 +1,36 @@
-const ONE_VAR_PLOTS = ["boxfill", "isofill", "isoline"] // meshfill can be either 1 or 2
-const TWO_VAR_PLOTS = ["vector", "3d_vector", "streamline"]
+const ONE_VAR_PLOTS = ["boxfill", "isofill", "isoline"]; // meshfill can be either 1 or 2
+const TWO_VAR_PLOTS = ["vector", "3d_vector", "streamline"];
+const UNARY_OPERATORS = [];
+const BINARY_OPERATORS = ["+", "-", "^", "/", ">>", "<<", "%", "*", "**", "|", "&", ">", "<", ">=", "<=", "!=", "=="];
 
 const JOYRIDE_STEPS = [
     {
-        title: 'Welcome to vCDAT!',
-        text: 'The following tour will help guide you through the basic features of vCDAT. '.concat(
+        title: "Welcome to vCDAT!",
+        text: "The following tour will help guide you through the basic features of vCDAT. ".concat(
             'Click "Next" to continue the tour. ',
             '<div class="contact-us-link">Found a bug or need help? ',
             '<a href="https://github.com/CDAT/vcdat/wiki/Contact-Us" target="_blank">Contact Us</a></div>'
         ),
-        selector: '.joyride',
-        position: 'top',
-        type: 'click',
+        selector: ".joyride",
+        position: "top",
+        type: "click",
         style: {
             arrow: {
-                display: 'none'
+                display: "none"
             },
             skip: {
-                color: '#f04'
-            },
-        }   
+                color: "#f04"
+            }
+        }
     },
     {
-        title: 'Plot Parts',
-        text: 'There are three parts to any given plot. Variables, a Graphics Method, and a Template.'.concat(
-            ' Each of these can be dragged and dropped into a cell.'
+        title: "Plot Parts",
+        text: "There are three parts to any given plot. Variables, a Graphics Method, and a Template.".concat(
+            " Each of these can be dragged and dropped into a cell."
         ),
-        selector: '#left-side-bar',
-        position: 'right',
-        type: 'click',
+        selector: "#left-side-bar",
+        position: "right",
+        type: "click",
         style: {
             hole: {
                 marginTop: "-1px"
@@ -36,51 +38,52 @@ const JOYRIDE_STEPS = [
         }
     },
     {
-        title: 'Variables',
+        title: "Variables",
         text: 'Use the <span style="color: rgba(40, 167, 69, 0.8);">Add</span> <span style="color: rgba(217, 120, 36, 0.8);">Edit</span> and '.concat(
             '<span style="color: rgba(196, 28, 31, 0.8);">Delete</span> buttons to modify what variables are loaded. ',
-            'In order to edit or delete a variable, ',
+            "In order to edit or delete a variable, ",
             'click on it to <span style="color: white; background-color: #df691a;">Select</span> it first. ',
-            'Graphics Methods and Templates can be edited in the same manner.'
-        ), 
-        selector: '.var-list-container',
-        position: 'right',
-        type: 'click',
+            "Graphics Methods and Templates can be edited in the same manner."
+        ),
+        selector: ".var-list-container",
+        position: "right",
+        type: "click"
     },
     {
-        title: 'Graphics Methods',
-        text: 'Graphics Methods define what the plot itself should look like. '.concat(
+        title: "Graphics Methods",
+        text: "Graphics Methods define what the plot itself should look like. ".concat(
             '<span style="color: white; background-color: #df691a;">Select</span> one to edit the colormap, projection, and more.'
         ),
-        selector: '.gm-list-container',
-        position: 'right',
-        type: 'click',
+        selector: ".gm-list-container",
+        position: "right",
+        type: "click"
     },
     {
-        title: 'Templates',
-        text: 'Templates define how the plot is presented. '.concat(
-            'They control everything about the labels and axes as well as the size and location of the plots inside a cell.'
+        title: "Templates",
+        text: "Templates define how the plot is presented. ".concat(
+            "They control everything about the labels and axes as well as the size and location of the plots inside a cell."
         ),
-        selector: '.template-list-container',
-        position: 'right',
-        type: 'click',
+        selector: ".template-list-container",
+        position: "right",
+        type: "click"
     },
     {
-        title: 'Spreadsheet',
-        text: 'The spreadsheet is made up of Cells. Each cell provides areas to drop variables, '.concat(
-            'graphics methods and templates, as well as an area to drop these items to create a new plot within the cell. ',
-            'Clicking on a cell will select it.'
+        title: "Spreadsheet",
+        text: "The spreadsheet is made up of Cells. Each cell provides areas to drop variables, ".concat(
+            "graphics methods and templates, as well as an area to drop these items to create a new plot within the cell. ",
+            "Clicking on a cell will select it."
         ),
-        selector: '.spreadsheet-div',
-        position: 'top',
-        type: 'click',
+        selector: ".spreadsheet-div",
+        position: "top",
+        type: "click"
     },
     {
-        title: 'Spreadsheet Toolbar',
-        text: 'The spreadsheet toolbar controls how many rows and columns of cells should be in a given sheet. It also allows for creating and switching between sheets.',
-        selector: '.spreadsheet-toolbar',
-        position: 'right',
-        type: 'click',
+        title: "Spreadsheet Toolbar",
+        text:
+            "The spreadsheet toolbar controls how many rows and columns of cells should be in a given sheet. It also allows for creating and switching between sheets.",
+        selector: ".spreadsheet-toolbar",
+        position: "right",
+        type: "click",
         style: {
             hole: {
                 marginTop: "-1px"
@@ -88,30 +91,32 @@ const JOYRIDE_STEPS = [
         }
     },
     {
-        title: 'Inspecting Plots',
-        text: 'When a cell is selected, each plot inside the cell is listed here. '.concat(
-            'Use this window to inspect and change things such as the variables or templates that define the plot, ',
-            'as well as remove plots when there is more than one in a cell.'
+        title: "Inspecting Plots",
+        text: "When a cell is selected, each plot inside the cell is listed here. ".concat(
+            "Use this window to inspect and change things such as the variables or templates that define the plot, ",
+            "as well as remove plots when there is more than one in a cell."
         ),
-        selector: '.plot-inspector-container',
-        position: 'right',
-        type: 'click',
+        selector: ".plot-inspector-container",
+        position: "right",
+        type: "click"
     },
     {
-        title: 'Tools',
-        text: 'The tools section contains various tools and actions that you may find useful. '.concat(
+        title: "Tools",
+        text: "The tools section contains various tools and actions that you may find useful. ".concat(
             '</br><span style="color: green;">Add Plot</span> will add an additional plot to a cell. ',
-            'Use this as an overlay or as an in-cell side-by-side comparison.',
+            "Use this as an overlay or as an in-cell side-by-side comparison.",
             '</br><span style="color: red;">Clear Cell</span> will reset the cell back to the default. ',
-            'This can be undone if you accidentally click it with the undo button.',
+            "This can be undone if you accidentally click it with the undo button.",
             '</br><span style="color: blue;">Colormap Editor</span> will open a window for creating, editing, and applying colormaps.'
         ),
-        selector: '.tools-container',
-        position: 'right',
-        type: 'click',
-    },
-]
+        selector: ".tools-container",
+        position: "right",
+        type: "click"
+    }
+];
 
-export { JOYRIDE_STEPS }
-export { ONE_VAR_PLOTS }
-export { TWO_VAR_PLOTS }
+export { JOYRIDE_STEPS };
+export { ONE_VAR_PLOTS };
+export { TWO_VAR_PLOTS };
+export { BINARY_OPERATORS };
+export { UNARY_OPERATORS };

--- a/frontend/src/js/constants/Constants.js
+++ b/frontend/src/js/constants/Constants.js
@@ -1,7 +1,7 @@
 const ONE_VAR_PLOTS = ["boxfill", "isofill", "isoline"]; // meshfill can be either 1 or 2
 const TWO_VAR_PLOTS = ["vector", "3d_vector", "streamline"];
 const UNARY_OPERATORS = ["-", "~", "not"];
-const BINARY_OPERATORS = ["+", "-", "^", "/", ">>", "<<", "%", "*", "**", "|", "&", ">", "<", ">=", "<=", "!=", "=="];
+const BINARY_OPERATORS = ["+", "-", "^", "/", ">>", "<<", "%", "*", "**", "|", "&", ">", "<", ">=", "<=", "!=", "==", "regrid"];
 
 const JOYRIDE_STEPS = [
     {

--- a/frontend/src/js/models/Variables.js
+++ b/frontend/src/js/models/Variables.js
@@ -18,8 +18,10 @@ class VariablesModel extends BaseModel {
                 return new_state;
             case "UPDATE_VARIABLE":
                 new_state = $.extend(true, {}, state);
+                var axis_list = $.extend(true, [], action.axis_list);
                 var new_dimensions = $.extend(true, [], action.dimensions);
                 var new_transforms = $.extend(true, {}, action.transforms);
+                new_state[action.name].axisList = axis_list;
                 new_state[action.name].dimension = new_dimensions;
                 new_state[action.name].transforms = new_transforms;
                 return new_state;

--- a/frontend/src/js/models/Variables.js
+++ b/frontend/src/js/models/Variables.js
@@ -1,32 +1,32 @@
 /* globals $ */
-import BaseModel from './BaseModel.js';
-
+import BaseModel from "./BaseModel.js";
 
 class VariablesModel extends BaseModel {
     static reduce(state = {}, action) {
-        var new_state
+        var new_state;
         switch (action.type) {
-            case 'LOAD_VARIABLES':
-                var new_list = Object.assign({}, state); 
-                action.var_list.forEach((var_obj) => {
+            case "LOAD_VARIABLES":
+                var new_list = Object.assign({}, state);
+                action.var_list.forEach(var_obj => {
                     let key = Object.keys(var_obj)[0];
                     new_list[key] = var_obj[key];
-                })
+                });
                 return new_list;
-            case 'REMOVE_VARIABLE': // Removes variable from list of loaded variables (left side bar)
-                new_state = $.extend(true, {}, state) 
-                delete new_state[action.name]
-                return new_state
-            case 'UPDATE_VARIABLE':
-                new_state = $.extend(true, {}, state)
-                var new_dimensions = $.extend(true, [], action.dimensions)
-                var new_transforms = $.extend(true, {}, action.transforms)
-                new_state[action.name].dimension = new_dimensions
-                new_state[action.name].transforms = new_transforms
-                return new_state
-            default: return state
+            case "REMOVE_VARIABLE": // Removes variable from list of loaded variables (left side bar)
+                new_state = $.extend(true, {}, state);
+                delete new_state[action.name];
+                return new_state;
+            case "UPDATE_VARIABLE":
+                new_state = $.extend(true, {}, state);
+                var new_dimensions = $.extend(true, [], action.dimensions);
+                var new_transforms = $.extend(true, {}, action.transforms);
+                new_state[action.name].dimension = new_dimensions;
+                new_state[action.name].transforms = new_transforms;
+                return new_state;
+            default:
+                return state;
         }
     }
 }
 
-export default VariablesModel
+export default VariablesModel;

--- a/frontend/test/mocha/components/Modals/CachedFiles/Tabs/FileTabTest.jsx
+++ b/frontend/test/mocha/components/Modals/CachedFiles/Tabs/FileTabTest.jsx
@@ -260,9 +260,16 @@ describe("FileTabTest.jsx", function() {
 
     it("Drop error is caught, and state isnt set", () => {
         let log = console.log; // eslint-disable-line no-console
-        console.log = function() {
+        let error = console.error;
+        /* prettier-ignore */
+        console.log = function() { // eslint-disable-line no-console
             return;
-        }; // eslint-disable-line no-console
+        };
+
+        /* prettier-ignore */
+        console.error = function(e) { // eslint-disable-line no-console
+            return;
+        };
         const set_item_spy = sinon.stub().throws();
         global.window.localStorage = { setItem: set_item_spy }; // localStorage doesnt exist during testing, so mock it
         const store = createMockStore(state);
@@ -285,6 +292,7 @@ describe("FileTabTest.jsx", function() {
         sinon.assert.calledOnce(set_item_spy);
         expect(cached_files.state().bookmarkFiles.length).to.equal(0);
         console.log = log; // eslint-disable-line no-console
+        console.error = error; // eslint-disable-line no-console
     });
 
     it("Deletes bookmarks", () => {

--- a/frontend/test/mocha/components/Modals/CachedFiles/Tabs/FileTabTest.jsx
+++ b/frontend/test/mocha/components/Modals/CachedFiles/Tabs/FileTabTest.jsx
@@ -1,15 +1,15 @@
 /* globals it, describe, before, beforeEach, */
-var chai = require('chai')
+var chai = require("chai");
 var expect = chai.expect;
-var React = require('react')
+var React = require("react");
 
-import FileTab, { getDefaultVariable } from '../../../../../../src/js/components/modals/CachedFiles/Tabs/FileTab.jsx'
-import Enzyme from 'enzyme' 
-import Adapter from 'enzyme-adapter-react-16'
-Enzyme.configure({ adapter: new Adapter() })
-import { shallow } from 'enzyme'
-import sinon from 'sinon'
-import { createMockStore } from 'redux-test-utils'
+import FileTab, { getDefaultVariable } from "../../../../../../src/js/components/modals/CachedFiles/Tabs/FileTab.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import sinon from "sinon";
+import { createMockStore } from "redux-test-utils";
 
 const props = {
     onTryClose: sinon.spy(),
@@ -17,144 +17,160 @@ const props = {
     curVariables: {},
     loadVariables: sinon.spy(),
     switchTab: sinon.spy(),
-    selectedTab: "file",
-}
+    selectedTab: "file"
+};
 
-const state = { 
+const state = {
     present: {
         cached_files: {
             recent_local_path: undefined
         }
     }
-}
+};
 
-describe('FileTabTest.jsx', function() {
-    it('Renders without exploding', () => {
-        const store = createMockStore(state)
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive() // dive gives us the FileTab component instead of the redux wrapper
+describe("FileTabTest.jsx", function() {
+    it("Renders without exploding", () => {
+        const store = createMockStore(state);
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive(); // dive gives us the FileTab component instead of the redux wrapper
         expect(cached_files).to.have.lengthOf(1);
     });
 
-    it('Getting selectedFilePath returns clean paths', () => {
-        const store = createMockStore(state)
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive()
+    it("Getting selectedFilePath returns clean paths", () => {
+        const store = createMockStore(state);
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive();
         expect(cached_files).to.have.lengthOf(1);
-        cached_files.setState({selectedFile: {path: "/example/path/to/test/", name: "filename.txt"}}) // good path
-        expect(cached_files.instance().selectedFilePath).to.equal("/example/path/to/test/filename.txt")
+        cached_files.setState({ selectedFile: { path: "/example/path/to/test/", name: "filename.txt" } }); // good path
+        expect(cached_files.instance().selectedFilePath).to.equal("/example/path/to/test/filename.txt");
 
-        cached_files.setState({selectedFile: {path: "example/path/to/test/", name: "filename.txt"}}) // no leading slash
-        expect(cached_files.instance().selectedFilePath).to.equal("/example/path/to/test/filename.txt")
+        cached_files.setState({ selectedFile: { path: "example/path/to/test/", name: "filename.txt" } }); // no leading slash
+        expect(cached_files.instance().selectedFilePath).to.equal("/example/path/to/test/filename.txt");
 
-        cached_files.setState({selectedFile: {path: "/example/path/to/test", name: "filename.txt"}}) // no trailing slash
-        expect(cached_files.instance().selectedFilePath).to.equal("/example/path/to/test/filename.txt")
+        cached_files.setState({ selectedFile: { path: "/example/path/to/test", name: "filename.txt" } }); // no trailing slash
+        expect(cached_files.instance().selectedFilePath).to.equal("/example/path/to/test/filename.txt");
 
-        cached_files.setState({selectedFile: {path: "example/path/to/test", name: "filename.txt"}}) // no leading or trailing slash
-        expect(cached_files.instance().selectedFilePath).to.equal("/example/path/to/test/filename.txt")
+        cached_files.setState({ selectedFile: { path: "example/path/to/test", name: "filename.txt" } }); // no leading or trailing slash
+        expect(cached_files.instance().selectedFilePath).to.equal("/example/path/to/test/filename.txt");
 
-        cached_files.setState({selectedFile: {path: "", name: "filename.txt"}}) // filename only
-        expect(cached_files.instance().selectedFilePath).to.equal("/filename.txt")
+        cached_files.setState({ selectedFile: { path: "", name: "filename.txt" } }); // filename only
+        expect(cached_files.instance().selectedFilePath).to.equal("/filename.txt");
 
-        cached_files.setState({selectedFile: undefined}) // no path
-        expect(cached_files.instance().selectedFilePath).to.equal('')
+        cached_files.setState({ selectedFile: undefined }); // no path
+        expect(cached_files.instance().selectedFilePath).to.equal("");
     });
 
-    it('VariableName getter works', () => {
-        const store = createMockStore(state)
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive()
+    it("VariableName getter works", () => {
+        const store = createMockStore(state);
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive();
         cached_files.setState({
             variablesAxes: [
-                {dummyName: {
-                    axisList: ["latitude", "longitude"],
-                    shape: [1,2,80,97],
-                    bounds: null,
-                    lonLat: null,
-                    gridType: "rectilinear",
-                    name: "A dummy variable for testing",
-                    units: "m/s",
-                }},
-                {second: {
-                    shape: [1,2,80,97],
-                    name: "A second dummy variable for testing",
-                    units: "m/s",
-                    data: [200, 800]
-                }}
+                {
+                    dummyName: {
+                        axisList: ["latitude", "longitude"],
+                        shape: [1, 2, 80, 97],
+                        bounds: null,
+                        lonLat: null,
+                        gridType: "rectilinear",
+                        name: "A dummy variable for testing",
+                        units: "m/s"
+                    }
+                },
+                {
+                    second: {
+                        shape: [1, 2, 80, 97],
+                        name: "A second dummy variable for testing",
+                        units: "m/s",
+                        data: [200, 800]
+                    }
+                }
             ],
             selectedVariableName: "dummyName",
-            redefinedVariableName: "redefinedName",
-        })
-        expect(cached_files.instance().variableName).to.equal("redefinedName")
+            redefinedVariableName: "redefinedName"
+        });
+        expect(cached_files.instance().variableName).to.equal("redefinedName");
 
         cached_files.setState({
             variablesAxes: [
-                {dummyName: {
-                    axisList: ["latitude", "longitude"],
-                    shape: [1,2,80,97],
-                    bounds: null,
-                    lonLat: null,
-                    gridType: "rectilinear",
-                    name: "A dummy variable for testing",
-                    units: "m/s",  
-                }},
-                {second: {
-                    shape: [1,2,80,97],
-                    name: "A second dummy variable for testing",
-                    units: "m/s",
-                    data: [200, 800]
-                }}
+                {
+                    dummyName: {
+                        axisList: ["latitude", "longitude"],
+                        shape: [1, 2, 80, 97],
+                        bounds: null,
+                        lonLat: null,
+                        gridType: "rectilinear",
+                        name: "A dummy variable for testing",
+                        units: "m/s"
+                    }
+                },
+                {
+                    second: {
+                        shape: [1, 2, 80, 97],
+                        name: "A second dummy variable for testing",
+                        units: "m/s",
+                        data: [200, 800]
+                    }
+                }
             ],
             selectedVariableName: "dummyName",
-            redefinedVariableName: undefined,
-        })
-        expect(cached_files.instance().variableName).to.equal("dummyName")
+            redefinedVariableName: undefined
+        });
+        expect(cached_files.instance().variableName).to.equal("dummyName");
 
         cached_files.setState({
             variablesAxes: [
-                {dummyName: {
-                    axisList: ["latitude", "longitude"],
-                    shape: [1,2,80,97],
-                    bounds: null,
-                    lonLat: null,
-                    gridType: "rectilinear",
-                    name: "A dummy variable for testing",
-                    units: "m/s"
-                }},
-                {second: {
-                    shape: [1,2,80,97],
-                    name: "A second dummy variable for testing",
-                    units: "m/s",
-                    data: [200, 800]
-                }}
+                {
+                    dummyName: {
+                        axisList: ["latitude", "longitude"],
+                        shape: [1, 2, 80, 97],
+                        bounds: null,
+                        lonLat: null,
+                        gridType: "rectilinear",
+                        name: "A dummy variable for testing",
+                        units: "m/s"
+                    }
+                },
+                {
+                    second: {
+                        shape: [1, 2, 80, 97],
+                        name: "A second dummy variable for testing",
+                        units: "m/s",
+                        data: [200, 800]
+                    }
+                }
             ],
             selectedVariableName: undefined,
-            redefinedVariableName: undefined,
-        })
-        expect(cached_files.instance().variableName).to.equal("")
+            redefinedVariableName: undefined
+        });
+        expect(cached_files.instance().variableName).to.equal("");
     });
 
-    it('LoadVariable and ComponentDidUpdate works', () => {
-        let spy = sinon.spy()
-        const store = createMockStore(state)
-        const cached_files = shallow(<FileTab {...props} loadVariables={spy} store={store}/>).dive()
+    it("LoadVariable and ComponentDidUpdate works", () => {
+        let spy = sinon.spy();
+        const store = createMockStore(state);
+        const cached_files = shallow(<FileTab {...props} loadVariables={spy} store={store} />).dive();
         cached_files.setState({
             variablesAxes: [
-                {dummyName: {
-                    axisList: ["latitude", "longitude"],
-                    shape: [1,2,80,97],
-                    bounds: null,
-                    lonLat: null,
-                    gridType: "rectilinear",
-                    name: "A dummy variable for testing",
-                    units: "m/s",
-                }},
-                {second: {
-                    shape: [1,2,80,97],
-                    name: "A second dummy variable for testing",
-                    units: "m/s",
-                    data: [200, 800]
-                }}
+                {
+                    dummyName: {
+                        axisList: ["latitude", "longitude"],
+                        shape: [1, 2, 80, 97],
+                        bounds: null,
+                        lonLat: null,
+                        gridType: "rectilinear",
+                        name: "A dummy variable for testing",
+                        units: "m/s"
+                    }
+                },
+                {
+                    second: {
+                        shape: [1, 2, 80, 97],
+                        name: "A second dummy variable for testing",
+                        units: "m/s",
+                        data: [200, 800]
+                    }
+                }
             ],
             selectedVariableName: "dummyName", // if this name is not present in variableAxes, an infinite loop occurs
-            selectedFile: {"path": "/fake/path", "name": "dummyFileName"},
+            selectedFile: { path: "/fake/path", name: "dummyFileName" },
             selectedVariable: {
                 axisList: ["latitude"],
                 bounds: null,
@@ -164,217 +180,230 @@ describe('FileTabTest.jsx', function() {
                 shape: [120, 46, 72],
                 units: "m/s"
             },
-            dimension: [
-                {axisName: "latitude"},
-            ]
-        })
-        cached_files.instance().loadVariable()
-        sinon.assert.calledOnce(spy)
-        expect(cached_files.state().redefinedVariableName).to.equal("")
-    })
-
-    it('Starting and ending a drag sets state', () => {
-        const store = createMockStore(state)
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive()
-        let event = {
-            dataTransfer:{
-                setData: function(){return}
-            }
-        }
-        expect(cached_files.state().showBookmarkZone).to.be.false
-        cached_files.instance().handleDragStart(event, {})
-        expect(cached_files.state().showBookmarkZone).to.be.true
-        cached_files.instance().handleDragEnd(event)
-        expect(cached_files.state().showBookmarkZone).to.be.false
+            dimension: [{ axisName: "latitude" }]
+        });
+        cached_files.instance().loadVariable();
+        sinon.assert.calledOnce(spy);
+        expect(cached_files.state().redefinedVariableName).to.equal("");
     });
 
-    it('Drop sets state', () => {
-        const store = createMockStore(state)
-        const set_item_spy = sinon.spy()
-        global.window.localStorage = { setItem: set_item_spy } // localStoarge doesnt exist during testing, so mock it 
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive()
+    it("Starting and ending a drag sets state", () => {
+        const store = createMockStore(state);
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive();
+        let event = {
+            dataTransfer: {
+                setData: function() {
+                    return;
+                }
+            }
+        };
+        expect(cached_files.state().showBookmarkZone).to.be.false;
+        cached_files.instance().handleDragStart(event, {});
+        expect(cached_files.state().showBookmarkZone).to.be.true;
+        cached_files.instance().handleDragEnd(event);
+        expect(cached_files.state().showBookmarkZone).to.be.false;
+    });
+
+    it("Drop sets state", () => {
+        const store = createMockStore(state);
+        const set_item_spy = sinon.spy();
+        global.window.localStorage = { setItem: set_item_spy }; // localStoarge doesnt exist during testing, so mock it
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive();
         let test_bookmark = {
             directory: false,
             modifiedTime: "Thu, 04 Jan 2018 19:00:00 GMT",
             name: "clt.nc",
             path: "/Users/user/sample_data//",
             subItems: {}
-        }
+        };
         let event = {
-            dataTransfer:{
-                getData: function(){
-                    return JSON.stringify(test_bookmark)
+            dataTransfer: {
+                getData: function() {
+                    return JSON.stringify(test_bookmark);
                 }
             }
-        }
-        cached_files.instance().handleDrop(event)
-        let bookmarks = cached_files.state().bookmarkFiles
-        let new_bookmark = bookmarks[bookmarks.length-1]
-        sinon.assert.calledOnce(set_item_spy)
-        expect(new_bookmark.modifiedTime).to.equal(test_bookmark.modifiedTime)
-        expect(new_bookmark.name).to.equal(test_bookmark.name) 
-        expect(new_bookmark.path).to.equal(test_bookmark.path)
-    })
+        };
+        cached_files.instance().handleDrop(event);
+        let bookmarks = cached_files.state().bookmarkFiles;
+        let new_bookmark = bookmarks[bookmarks.length - 1];
+        sinon.assert.calledOnce(set_item_spy);
+        expect(new_bookmark.modifiedTime).to.equal(test_bookmark.modifiedTime);
+        expect(new_bookmark.name).to.equal(test_bookmark.name);
+        expect(new_bookmark.path).to.equal(test_bookmark.path);
+    });
 
-    it('Shouldnt add duplicate bookmarks', () => {
-        const store = createMockStore(state)
-        const set_item_spy = sinon.spy()
-        global.window.localStorage = { setItem: set_item_spy } // localStoarge doesnt exist during testing, so mock it 
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive()
+    it("Shouldnt add duplicate bookmarks", () => {
+        const store = createMockStore(state);
+        const set_item_spy = sinon.spy();
+        global.window.localStorage = { setItem: set_item_spy }; // localStoarge doesnt exist during testing, so mock it
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive();
         let test_bookmark = {
             directory: false,
             modifiedTime: "Thu, 04 Jan 2018 19:00:00 GMT",
             name: "clt.nc",
             path: "/Users/user/sample_data//",
             subItems: {}
-        }
+        };
         let event = {
-            dataTransfer:{
-                getData: function(){
-                    return JSON.stringify(test_bookmark)
+            dataTransfer: {
+                getData: function() {
+                    return JSON.stringify(test_bookmark);
                 }
             }
-        }
-        cached_files.setState({bookmarkFiles: [test_bookmark]}) // manually add test_bookmark as a bookmark
-        expect(cached_files.state().bookmarkFiles.length).to.equal(1)
-        cached_files.instance().handleDrop(event)
-        expect(set_item_spy.notCalled).to.be.true
-        expect(cached_files.state().bookmarkFiles.length).to.equal(1)
-    })
+        };
+        cached_files.setState({ bookmarkFiles: [test_bookmark] }); // manually add test_bookmark as a bookmark
+        expect(cached_files.state().bookmarkFiles.length).to.equal(1);
+        cached_files.instance().handleDrop(event);
+        expect(set_item_spy.notCalled).to.be.true;
+        expect(cached_files.state().bookmarkFiles.length).to.equal(1);
+    });
 
-    it('Drop error is caught, and state isnt set', () => {
-        let log = console.log // eslint-disable-line no-console
-        console.log = function(){return} // eslint-disable-line no-console
-        const set_item_spy = sinon.stub().throws()
-        global.window.localStorage = { setItem: set_item_spy } // localStorage doesnt exist during testing, so mock it 
-        const store = createMockStore(state)
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive()
+    it("Drop error is caught, and state isnt set", () => {
+        let log = console.log; // eslint-disable-line no-console
+        console.log = function() {
+            return;
+        }; // eslint-disable-line no-console
+        const set_item_spy = sinon.stub().throws();
+        global.window.localStorage = { setItem: set_item_spy }; // localStorage doesnt exist during testing, so mock it
+        const store = createMockStore(state);
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive();
         let test_bookmark = {
             directory: false,
             modifiedTime: "Thu, 04 Jan 2018 19:00:01 GMT",
             name: "clt.nc",
             path: "/Users/user/sample_data//",
             subItems: {}
-        }
+        };
         let event = {
-            dataTransfer:{
-                getData: function(){
-                    return JSON.stringify(test_bookmark)
+            dataTransfer: {
+                getData: function() {
+                    return JSON.stringify(test_bookmark);
                 }
             }
-        }
-        cached_files.instance().handleDrop(event)
-        sinon.assert.calledOnce(set_item_spy)
-        expect(cached_files.state().bookmarkFiles.length).to.equal(0)
-        console.log = log // eslint-disable-line no-console
+        };
+        cached_files.instance().handleDrop(event);
+        sinon.assert.calledOnce(set_item_spy);
+        expect(cached_files.state().bookmarkFiles.length).to.equal(0);
+        console.log = log; // eslint-disable-line no-console
     });
 
-    it('Deletes bookmarks', () => {
-        const store = createMockStore(state)
-        const set_item_spy = sinon.spy()
-        global.window.localStorage = { setItem: set_item_spy } // localStoarge doesnt exist during testing, so mock it 
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive()
+    it("Deletes bookmarks", () => {
+        const store = createMockStore(state);
+        const set_item_spy = sinon.spy();
+        global.window.localStorage = { setItem: set_item_spy }; // localStoarge doesnt exist during testing, so mock it
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive();
         let test_bookmark = {
             directory: false,
             modifiedTime: "Thu, 04 Jan 2018 19:00:00 GMT",
             name: "clt.nc",
             path: "/Users/user/sample_data//",
             subItems: {}
-        }
-        cached_files.setState({bookmarkFiles: [test_bookmark]}) // manually add test_bookmark as a bookmark
-        expect(cached_files.state().bookmarkFiles.length).to.equal(1)
-        cached_files.instance().handleDeleteBookmark(0)
-        sinon.assert.calledOnce(set_item_spy)
-        expect(cached_files.state().bookmarkFiles.length).to.equal(0)
-    })
+        };
+        cached_files.setState({ bookmarkFiles: [test_bookmark] }); // manually add test_bookmark as a bookmark
+        expect(cached_files.state().bookmarkFiles.length).to.equal(1);
+        cached_files.instance().handleDeleteBookmark(0);
+        sinon.assert.calledOnce(set_item_spy);
+        expect(cached_files.state().bookmarkFiles.length).to.equal(0);
+    });
 
-    it('Handles file selection', () => {
+    it("Handles file selection", () => {
         global.vcs = {
-            variables: () => { 
+            allvariables: () => {
                 return Promise.resolve([
-                    { clt: {
-                        gridType: "rectilinear",
-                        name: "Total cloudiness",
-                        axisList: ["time", "latitude", "longitude"],
-                        bounds: null,
-                        shape: [0, 1, 2],
-                        units: "%",
-                    }},
-                    { second: {
-                        shape: [1,2,80,97],
-                        name: "A second dummy variable for testing",
-                        units: "m/s",
-                        data: [200, 800]
-                    }}
-                ])
+                    {
+                        clt: {
+                            gridType: "rectilinear",
+                            name: "Total cloudiness",
+                            axisList: ["time", "latitude", "longitude"],
+                            bounds: null,
+                            shape: [0, 1, 2],
+                            units: "%"
+                        }
+                    },
+                    {
+                        second: {
+                            shape: [1, 2, 80, 97],
+                            name: "A second dummy variable for testing",
+                            units: "m/s",
+                            data: [200, 800]
+                        }
+                    }
+                ]);
             }
-        }
-        const store = createMockStore(state)
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive()
+        };
+        const store = createMockStore(state);
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive();
         let file = {
             name: "dummyFile",
             path: "/some/dummy/path/"
-        }
-        const set_item_spy = sinon.stub()
-        global.window.localStorage = { setItem: set_item_spy } // localStorage doesnt exist during testing, so mock it 
-        cached_files.setState({ showFileExplorer: true, selectedVariableName: "" })
-        expect(cached_files.state().historyFiles.length).to.equal(0)
+        };
+        const set_item_spy = sinon.stub();
+        global.window.localStorage = { setItem: set_item_spy }; // localStorage doesnt exist during testing, so mock it
+        cached_files.setState({ showFileExplorer: true, selectedVariableName: "" });
+        expect(cached_files.state().historyFiles.length).to.equal(0);
         // handleFileSelected is asynchronous, we return the promise to mocha and it will handle it properly
-        return cached_files.instance().handleFileSelected(file).then(() => {
-            expect(cached_files.state().showFileExplorer).to.be.false
-            expect(cached_files.state().selectedVariableName).to.equal("clt")
-            cached_files.setState(cached_files.state()) // work around for componentDidUpdate not firing in shallow
-            expect(cached_files.state().selectedVariable.name).to.equal("Total cloudiness")
-        })
+        return cached_files
+            .instance()
+            .handleFileSelected(file)
+            .then(() => {
+                expect(cached_files.state().showFileExplorer).to.be.false;
+                expect(cached_files.state().selectedVariableName).to.equal("clt");
+                cached_files.setState(cached_files.state()); // work around for componentDidUpdate not firing in shallow
+                expect(cached_files.state().selectedVariable.name).to.equal("Total cloudiness");
+            });
     });
 
-    it('Handles dimension value changes', () => {
-        const store = createMockStore(state)
-        const cached_files = shallow(<FileTab {...props} store={store}/>).dive()
+    it("Handles dimension value changes", () => {
+        const store = createMockStore(state);
+        const cached_files = shallow(<FileTab {...props} store={store} />).dive();
         cached_files.setState({
             variablesAxes: [
-                {dummyName: {
-                    axisList: ["latitude", "longitude"],
-                    shape: [1,2,80,97],
-                    bounds: null,
-                    lonLat: null,
-                    gridType: "rectilinear",
-                    name: "A dummy variable for testing",
-                    units: "m/s",
-                }},
-                {second: {
-                    shape: [1,2,80,97],
-                    name: "A second dummy variable for testing",
-                    units: "m/s",
-                    data: [200, 800]
-                }}
+                {
+                    dummyName: {
+                        axisList: ["latitude", "longitude"],
+                        shape: [1, 2, 80, 97],
+                        bounds: null,
+                        lonLat: null,
+                        gridType: "rectilinear",
+                        name: "A dummy variable for testing",
+                        units: "m/s"
+                    }
+                },
+                {
+                    second: {
+                        shape: [1, 2, 80, 97],
+                        name: "A second dummy variable for testing",
+                        units: "m/s",
+                        data: [200, 800]
+                    }
+                }
             ],
             selectedVariableName: "dummyName",
-            dimension: [
-                {axisName: "latitude"},
-            ]
-        })
-        cached_files.instance().handleDimensionValueChange({
-            range: [0, 10],
-            stride: 1
-        }, "latitude")
-        expect(cached_files.state().dimension[0].values.range[0]).to.equal(0)
-        expect(cached_files.state().dimension[0].values.range[1]).to.equal(10)
-        expect(cached_files.state().dimension[0].values.stride).to.equal(1)
+            dimension: [{ axisName: "latitude" }]
+        });
+        cached_files.instance().handleDimensionValueChange(
+            {
+                range: [0, 10],
+                stride: 1
+            },
+            "latitude"
+        );
+        expect(cached_files.state().dimension[0].values.range[0]).to.equal(0);
+        expect(cached_files.state().dimension[0].values.range[1]).to.equal(10);
+        expect(cached_files.state().dimension[0].values.stride).to.equal(1);
     });
 
-    it('Selects a default variable that is not a bounds variable', () => {
-        let invalid_variables = ['var_lat', 'var_lon', 'lon_var', 'lat_var', 'variable_bounds','bnds_variable', 'axis']
-        let valid_variables = ['z', 'c', 'y']
+    it("Selects a default variable that is not a bounds variable", () => {
+        let invalid_variables = ["var_lat", "var_lon", "lon_var", "lat_var", "variable_bounds", "bnds_variable", "axis"];
+        let valid_variables = ["z", "c", "y"];
 
         // if all variables are invalid, it should return the first sorted name
-        expect(getDefaultVariable(invalid_variables)).to.equal('axis')
+        expect(getDefaultVariable(invalid_variables)).to.equal("axis");
 
         // The function should sort the array and return the first match
-        expect(getDefaultVariable(valid_variables)).to.equal('c')
+        expect(getDefaultVariable(valid_variables)).to.equal("c");
 
         // After sorting, it should ignore invalid matches and return the first sorted match
-        expect(getDefaultVariable(invalid_variables.concat(valid_variables))).to.equal('c')
+        expect(getDefaultVariable(invalid_variables.concat(valid_variables))).to.equal("c");
     });
-
 });

--- a/frontend/test/mocha/components/Modals/Calculator/CalculatorButtonsTest.jsx
+++ b/frontend/test/mocha/components/Modals/Calculator/CalculatorButtonsTest.jsx
@@ -1,0 +1,22 @@
+/* globals it, describe, before, beforeEach, */
+var chai = require("chai");
+var expect = chai.expect;
+var React = require("react");
+
+import CalculatorButtons from "../../../../../src/js/components/modals/Calculator/CalculatorButtons.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+
+const getProps = () => {
+    return {};
+};
+
+describe("CalculatorButtonsTest.jsx", function() {
+    it("renders without exploding", () => {
+        let props = getProps();
+        let calculator_buttons = shallow(<CalculatorButtons {...props} />);
+        expect(calculator_buttons).to.have.lengthOf(1);
+    });
+});

--- a/frontend/test/mocha/components/Modals/Calculator/CalculatorTest.jsx
+++ b/frontend/test/mocha/components/Modals/Calculator/CalculatorTest.jsx
@@ -881,4 +881,41 @@ describe("CalculatorTest.jsx", function() {
             expect(calculator.instance().printCalculation()).to.equal(test_case.expected);
         });
     });
+
+    test_cases = [
+        { left: undefined, operator: undefined, right: undefined, expected: "" },
+        { left: { value: "0", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "-0" },
+        { left: { value: "-0", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "0" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "-1" },
+        { left: { value: "-1", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "1" },
+        { left: { value: "12", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "-12" },
+        { left: { value: "-12", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "12" },
+        { left: { value: "12.", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "-12." },
+        { left: { value: "-12.", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "12." },
+        { left: { value: "12.0", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "-12.0" },
+        { left: { value: "-12.0", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "12.0" },
+        { left: { value: "clt", type: CALC_TYPES.var }, operator: undefined, right: undefined, expected: "clt" }, // not supported for variables.
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: undefined, expected: "1 +" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "0", type: CALC_TYPES.const }, expected: "1 + -0" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "0.", type: CALC_TYPES.const }, expected: "1 + -0." },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "0.1", type: CALC_TYPES.const }, expected: "1 + -0.1" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "-0.1", type: CALC_TYPES.const }, expected: "1 + 0.1" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "2", type: CALC_TYPES.const }, expected: "1 + -2" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "2.", type: CALC_TYPES.const }, expected: "1 + -2." },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "2.2", type: CALC_TYPES.const }, expected: "1 + -2.2" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "clt", type: CALC_TYPES.var }, expected: "1 + clt" }
+    ];
+    test_cases.forEach(function(test_case, index) {
+        it(`handlePlusMinus works. Case: ${index}`, function() {
+            let props = getProps();
+            let calculator = shallow(<Calculator {...props} />);
+            calculator.setState({
+                calculation_left_side: test_case.left,
+                calculation_operator: test_case.operator,
+                calculation_right_side: test_case.right
+            });
+            calculator.instance().handlePlusMinus();
+            expect(calculator.instance().printCalculation()).to.equal(test_case.expected);
+        });
+    });
 });

--- a/frontend/test/mocha/components/Modals/Calculator/CalculatorTest.jsx
+++ b/frontend/test/mocha/components/Modals/Calculator/CalculatorTest.jsx
@@ -1,0 +1,565 @@
+/* globals it, describe, before, beforeEach, */
+var chai = require("chai");
+var expect = chai.expect;
+var React = require("react");
+
+import { PureCalculator as Calculator, CALC_TYPES } from "../../../../../src/js/components/modals/Calculator/Calculator.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import sinon from "sinon";
+
+const getProps = () => {
+    return {
+        show: true,
+        close: sinon.spy(),
+        variables: {
+            clt: {
+                cdms_var_name: "clt",
+                axisList: ["time", "latitude", "longitude"],
+                filename: {
+                    directory: false,
+                    name: "clt.nc",
+                    path: "/Users/username/sample_data//",
+                    subItems: {}
+                },
+                path: "/Users/username/sample_data/clt.nc",
+                dimension: [
+                    {
+                        axisName: "time"
+                    },
+                    {
+                        axisName: "latitude"
+                    },
+                    {
+                        axisName: "longitude"
+                    }
+                ],
+                transforms: {}
+            },
+            u: {
+                cdms_var_name: "u",
+                axisList: ["time1", "plev", "latitude1", "longitude1"],
+                filename: {
+                    directory: false,
+                    name: "clt.nc",
+                    path: "/Users/username/sample_data//",
+                    subItems: {}
+                },
+                path: "/Users/username/sample_data/clt.nc",
+                dimension: [
+                    {
+                        axisName: "time1"
+                    },
+                    {
+                        axisName: "plev"
+                    },
+                    {
+                        axisName: "latitude1"
+                    },
+                    {
+                        axisName: "longitude1"
+                    }
+                ],
+                transforms: {}
+            },
+            v: {
+                cdms_var_name: "v",
+                axisList: ["time2", "plev1", "latitude2", "longitude2"],
+                filename: {
+                    directory: false,
+                    name: "clt.nc",
+                    path: "/Users/username/sample_data//",
+                    subItems: {}
+                },
+                path: "/Users/username/sample_data/clt.nc",
+                dimension: [
+                    {
+                        axisName: "time2"
+                    },
+                    {
+                        axisName: "plev1"
+                    },
+                    {
+                        axisName: "latitude2"
+                    },
+                    {
+                        axisName: "longitude2"
+                    }
+                ],
+                transforms: {}
+            },
+            clt_plus_2: {
+                dimension: [],
+                transforms: [],
+                json: "".concat(
+                    '{"derivation": [{"attribute_values": {"value": 2}, "node_type": "raw", "dependent_attributes": [], ',
+                    '"node_params": {"value": "Raw (JSON-compatible) value provided by this node."}}, ',
+                    '{"attribute_values": {"objtype": "variable", "uri": "/Users/username/sample_data/clt.nc", "objid": "clt"}, ',
+                    '"node_type": "dataset", "dependent_attributes": [], "node_params": {"objtype": "Type of object to retrieve.", ',
+                    '"uri": "URI for a dataset", "objid": "id of the object to retrieve"}}, {"attribute_values": ',
+                    '{"operator": "+", "left_value": 1, "right_value": 0}, "node_type": "arithmetic", "dependent_attributes": ',
+                    '["left_value", "right_value"], "node_params": {"operator": "Operator used for data transform", ',
+                    '"left_value": "Left-hand side of a binary operator", "right_value": "Right-hand side of a binary operator"}}]}'
+                )
+            }
+        },
+        variable_names: ["clt", "u", "v", "clt_plus_2"],
+        removeVariable: sinon.spy(),
+        loadVariable: sinon.spy()
+    };
+};
+
+describe("CalculatorTest.jsx", function() {
+    it("renders without exploding", () => {
+        let props = getProps();
+        let calculator = shallow(<Calculator {...props} />);
+        expect(calculator).to.have.lengthOf(1);
+    });
+
+    it("setInputFocus sets input_focus in state", () => {
+        let props = getProps();
+        let calculator = shallow(<Calculator {...props} />);
+        expect(calculator.state().input_focus).to.equal(false);
+        calculator.instance().setInputFocus(true);
+        expect(calculator.state().input_focus).to.equal(true);
+        calculator.instance().setInputFocus(false);
+        expect(calculator.state().input_focus).to.equal(false);
+    });
+
+    it("handleNewVariableName sets new_variable_name in state", () => {
+        let props = getProps();
+        let event = {
+            target: {
+                value: "newName"
+            }
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        expect(calculator.state().new_variable_name).to.equal("");
+        calculator.instance().handleNewVariableName(event);
+        expect(calculator.state().new_variable_name).to.equal(event.target.value);
+    });
+
+    it("handleVariable sets left side", () => {
+        let props = getProps();
+        let variable = {
+            name: "new_var"
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.instance().handleVariable(variable);
+        expect(calculator.state().calculation_left_side).to.deep.equal({
+            value: variable.name,
+            type: CALC_TYPES.var
+        });
+    });
+
+    it("handleVariable sets right side", () => {
+        let props = getProps();
+        let left_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let operator = "+";
+        let variable = {
+            name: "new_var"
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        // Left side and operator must be set for a second variable to be registered
+        calculator.setState({
+            calculation_left_side: left_side,
+            calculation_operator: operator
+        });
+        calculator.instance().handleVariable(variable);
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal({
+            value: variable.name,
+            type: CALC_TYPES.var
+        });
+    });
+
+    it("handleVariable does not set right side if the operator is unary", () => {
+        let props = getProps();
+        let left_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let operator = "~";
+        let variable = {
+            name: "new_var"
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        let right_side = calculator.state().calculation_right_side;
+        calculator.setState({
+            calculation_left_side: left_side,
+            calculation_operator: operator
+        });
+        calculator.instance().handleVariable(variable);
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal(right_side);
+    });
+
+    it("handleVariable does not set right side if there is no operator", () => {
+        let props = getProps();
+        let left_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let variable = {
+            name: "new_var"
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side
+        });
+        let operator = calculator.state().calculation_operator;
+        let right_side = calculator.state().calculation_right_side;
+        calculator.instance().handleVariable(variable);
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal(right_side);
+    });
+
+    it("handleConstant sets left side", function() {
+        let props = getProps();
+        let number = 2;
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.instance().handleConstant(number);
+        expect(calculator.state().calculation_left_side).to.deep.equal({
+            value: number.toString(),
+            type: CALC_TYPES.const
+        });
+    });
+
+    it("handleConstant appends to left side constant when there is no operator", function() {
+        let props = getProps();
+        let number = 2;
+        let left_side = {
+            value: "1", // must be a string
+            type: CALC_TYPES.const
+        };
+        let calculator = shallow(<Calculator {...props} />);
+
+        calculator.setState({
+            calculation_left_side: left_side
+        });
+        calculator.instance().handleConstant(number);
+
+        expect(calculator.state().calculation_left_side).to.deep.equal({
+            value: left_side.value + number.toString(),
+            type: CALC_TYPES.const
+        });
+    });
+
+    it("handleConstant does not change state when left side is a variable and no operator is set", function() {
+        let props = getProps();
+        let number = 2;
+        let left_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side
+        });
+        let state_before = calculator.state();
+
+        calculator.instance().handleConstant(number);
+        expect(calculator.state()).to.deep.equal(state_before);
+    });
+
+    it("handleConstant should not change state when the left side is set with a unary operator", function() {
+        let props = getProps();
+        let left_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let operator = "~";
+        let number = 2;
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side,
+            calculation_operator: operator
+        });
+        calculator.instance().handleConstant(number);
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+    });
+
+    it("handleConstant sets right side", function() {
+        let props = getProps();
+        let number = 2;
+        let left_side = {
+            value: "1",
+            type: CALC_TYPES.const
+        };
+        let operator = "+";
+        let calculator = shallow(<Calculator {...props} />);
+
+        calculator.setState({
+            calculation_left_side: left_side,
+            calculation_operator: operator
+        });
+        calculator.instance().handleConstant(number);
+        expect(calculator.state().calculation_right_side).to.deep.equal({
+            value: number.toString(),
+            type: CALC_TYPES.const
+        });
+
+        number = "2";
+        calculator.instance().handleConstant(number);
+
+        expect(calculator.state().calculation_right_side).to.deep.equal({
+            value: number.toString() + number.toString(),
+            type: CALC_TYPES.const
+        });
+    });
+
+    it("handleConstant handles a full calculation", function() {
+        let props = getProps();
+        let number = 2;
+        let left_side = {
+            value: "1",
+            type: CALC_TYPES.const
+        };
+        let operator = "+";
+        let right_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let calculator = shallow(<Calculator {...props} />);
+
+        calculator.setState({
+            calculation_left_side: left_side,
+            calculation_operator: operator,
+            calculation_right_side: right_side
+        });
+        calculator.instance().handleConstant(number);
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal(right_side);
+
+        number = "2";
+        calculator.instance().handleConstant(number);
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal(right_side);
+    });
+
+    it("handleClear sets state to undefined or empty string", () => {
+        let props = getProps();
+        let left_side = {
+            value: "1",
+            type: CALC_TYPES.const
+        };
+        let operator = "+";
+        let right_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let new_variable_name,
+            placeholder = "example";
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            new_variable_name: new_variable_name,
+            calculation_left_side: left_side,
+            calculation_operator: operator,
+            calculation_right_side: right_side,
+            placeholder_text: placeholder
+        });
+        expect(calculator.state().new_variable_name).to.deep.equal(new_variable_name);
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal(right_side);
+        expect(calculator.state().placeholder_text).to.deep.equal(placeholder);
+
+        calculator.instance().handleClear();
+
+        expect(calculator.state().new_variable_name).to.deep.equal("");
+        expect(calculator.state().calculation_left_side).to.deep.equal(undefined);
+        expect(calculator.state().calculation_operator).to.deep.equal(undefined);
+        expect(calculator.state().calculation_right_side).to.deep.equal(undefined);
+        expect(calculator.state().placeholder_text).to.deep.equal("");
+    });
+
+    it("handleDelete deletes from right side constants", () => {
+        let props = getProps();
+        let left_side = {
+            value: "1",
+            type: CALC_TYPES.const
+        };
+        let operator = "+";
+        let right_side = {
+            value: "22",
+            type: CALC_TYPES.const
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side,
+            calculation_operator: operator,
+            calculation_right_side: right_side
+        });
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal(right_side);
+
+        calculator.instance().handleDelete();
+
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side.value).to.equal("2");
+
+        calculator.instance().handleDelete();
+
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal(undefined);
+    });
+
+    it("handleDelete deletes from right side variables", () => {
+        let props = getProps();
+        let left_side = {
+            value: "1",
+            type: CALC_TYPES.const
+        };
+        let operator = "+";
+        let right_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side,
+            calculation_operator: operator,
+            calculation_right_side: right_side
+        });
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal(right_side);
+
+        calculator.instance().handleDelete();
+
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+        expect(calculator.state().calculation_right_side).to.deep.equal(undefined);
+    });
+
+    it("handleDelete deletes an operator if the right side is not defined", () => {
+        let props = getProps();
+        let left_side = {
+            value: "1",
+            type: CALC_TYPES.const
+        };
+        let operator = "+";
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side,
+            calculation_operator: operator
+        });
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+
+        calculator.instance().handleDelete();
+
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(undefined);
+    });
+
+    it("handleDelete deletes left side constants if operator is not defined", () => {
+        let props = getProps();
+        let left_side = {
+            value: "22",
+            type: CALC_TYPES.const
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side
+        });
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+
+        calculator.instance().handleDelete();
+
+        expect(calculator.state().calculation_left_side.value).to.equal("2");
+
+        calculator.instance().handleDelete();
+
+        expect(calculator.state().calculation_left_side).to.deep.equal(undefined);
+    });
+
+    it("handleDelete deletes left side variable if operator is not defined", () => {
+        let props = getProps();
+        let left_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side
+        });
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        calculator.instance().handleDelete();
+        expect(calculator.state().calculation_left_side).to.deep.equal(undefined);
+    });
+
+    it("handleDelete deletes left side variable if operator is not defined", () => {
+        let props = getProps();
+        let left_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side
+        });
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        calculator.instance().handleDelete();
+        expect(calculator.state().calculation_left_side).to.deep.equal(undefined);
+    });
+
+    it("handleoperator does not override existing operators", () => {
+        let props = getProps();
+        let left_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let old_operator = "+";
+        let new_operator = "-";
+        let calculator = shallow(<Calculator {...props} />);
+        calculator.setState({
+            calculation_left_side: left_side,
+            calculation_operator: old_operator
+        });
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(old_operator);
+        calculator.instance().handleOperator(new_operator);
+        expect(calculator.state().calculation_operator).to.deep.equal(old_operator);
+    });
+
+    it("handleoperator adds a unary operator even if the left side is undefined", () => {
+        let props = getProps();
+        let left_side = {
+            value: "clt",
+            type: CALC_TYPES.var
+        };
+        let operator = "~";
+        let calculator = shallow(<Calculator {...props} />);
+        // Check that operator is added when the left side is undefined
+        expect(calculator.state().calculation_left_side).to.deep.equal(undefined);
+        expect(calculator.state().calculation_operator).to.deep.equal(undefined);
+        calculator.instance().handleOperator(operator);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+
+        // Now check that operator is added with the left side defined
+        calculator.instance().handleClear();
+        expect(calculator.state().calculation_left_side).to.deep.equal(undefined);
+        expect(calculator.state().calculation_operator).to.deep.equal(undefined);
+        calculator.setState({
+            calculation_left_side: left_side
+        });
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        calculator.instance().handleOperator(operator);
+        expect(calculator.state().calculation_left_side).to.deep.equal(left_side);
+        expect(calculator.state().calculation_operator).to.deep.equal(operator);
+    });
+});

--- a/frontend/test/mocha/components/Modals/Calculator/CalculatorTest.jsx
+++ b/frontend/test/mocha/components/Modals/Calculator/CalculatorTest.jsx
@@ -630,6 +630,9 @@ describe("CalculatorTest.jsx", function() {
     });
 
     let test_cases = [
+        { left: undefined, operator: undefined, right: undefined, expected: "" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "1" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: undefined, expected: "1 +" },
         { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "2", type: CALC_TYPES.const }, expected: "1 + 2" },
         { left: { value: "1", type: CALC_TYPES.const }, operator: "-", right: { value: "clt", type: CALC_TYPES.var }, expected: "1 - clt" },
         { left: { value: "clt", type: CALC_TYPES.var }, operator: "/", right: { value: "2", type: CALC_TYPES.const }, expected: "clt / 2" },
@@ -847,5 +850,35 @@ describe("CalculatorTest.jsx", function() {
         };
         operand = calculator.instance().getOperand(calc_obj);
         expect(operand).to.deep.equal(expected);
+    });
+
+    test_cases = [
+        { left: undefined, operator: undefined, right: undefined, expected: "0." },
+        { left: { value: "0", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "0." },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "1." },
+        { left: { value: "12", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "12." },
+        { left: { value: "12.", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "12." },
+        { left: { value: "12.0", type: CALC_TYPES.const }, operator: undefined, right: undefined, expected: "12.0" },
+        { left: { value: "clt", type: CALC_TYPES.var }, operator: undefined, right: undefined, expected: "clt" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: undefined, expected: "1 + 0." },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "0.", type: CALC_TYPES.const }, expected: "1 + 0." },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "0.1", type: CALC_TYPES.const }, expected: "1 + 0.1" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "2", type: CALC_TYPES.const }, expected: "1 + 2." },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "2.", type: CALC_TYPES.const }, expected: "1 + 2." },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "2.2", type: CALC_TYPES.const }, expected: "1 + 2.2" },
+        { left: { value: "1", type: CALC_TYPES.const }, operator: "+", right: { value: "clt", type: CALC_TYPES.var }, expected: "1 + clt" }
+    ];
+    test_cases.forEach(function(test_case, index) {
+        it(`handleDecimal works. Case: ${index}`, function() {
+            let props = getProps();
+            let calculator = shallow(<Calculator {...props} />);
+            calculator.setState({
+                calculation_left_side: test_case.left,
+                calculation_operator: test_case.operator,
+                calculation_right_side: test_case.right
+            });
+            calculator.instance().handleDecimal();
+            expect(calculator.instance().printCalculation()).to.equal(test_case.expected);
+        });
     });
 });

--- a/frontend/test/mocha/components/Modals/Calculator/InputAreaTest.jsx
+++ b/frontend/test/mocha/components/Modals/Calculator/InputAreaTest.jsx
@@ -1,0 +1,31 @@
+/* globals it, describe, before, beforeEach, */
+var chai = require("chai");
+var expect = chai.expect;
+var React = require("react");
+
+import InputArea from "../../../../../src/js/components/modals/Calculator/InputArea.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import sinon from "sinon";
+
+// React-dnd is wrapping our component. This unwraps it.
+const PureInputArea = InputArea.DecoratedComponent;
+
+const getProps = () => {
+    return {
+        connectDropTarget: identity
+    };
+};
+
+// A dummy function so react-dnd doesn't complain
+const identity = el => el;
+
+describe("InputAreaTest.jsx", function() {
+    it("renders without exploding", () => {
+        let props = getProps();
+        let input_area = shallow(<PureInputArea {...props} />);
+        expect(input_area).to.have.lengthOf(1);
+    });
+});

--- a/frontend/test/mocha/components/Modals/Calculator/VariableListTest.jsx
+++ b/frontend/test/mocha/components/Modals/Calculator/VariableListTest.jsx
@@ -1,0 +1,25 @@
+/* globals it, describe, before, beforeEach, */
+var chai = require("chai");
+var expect = chai.expect;
+var React = require("react");
+
+import VariableList from "../../../../../src/js/components/modals/Calculator/VariableList.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import sinon from "sinon";
+
+const getProps = () => {
+    return {
+        variables: ["clt", "u", "v"]
+    };
+};
+
+describe("VariableListTest.jsx", function() {
+    it("renders without exploding", () => {
+        let props = getProps();
+        let variable_list = shallow(<VariableList {...props} />);
+        expect(variable_list).to.have.lengthOf(1);
+    });
+});

--- a/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/ColormapEditorTest.jsx
@@ -1,324 +1,352 @@
 /* globals it, describe, before, beforeEach, */
-var chai = require('chai')
+var chai = require("chai");
 var expect = chai.expect;
 var assert = chai.assert;
-var React = require('react')
+var React = require("react");
 
-import ColormapEditor from '../../../../../src/js/components/modals/ColormapEditor/ColormapEditor.jsx'
+import ColormapEditor from "../../../../../src/js/components/modals/ColormapEditor/ColormapEditor.jsx";
 // import { PureColormapEditor } from '../../../../../src/js/components/modals/ColormapEditor/ColormapEditor.jsx'
-import Enzyme from 'enzyme' 
-import Adapter from 'enzyme-adapter-react-16'
-Enzyme.configure({ adapter: new Adapter() })
-import { shallow } from 'enzyme'
-import { createMockStore } from 'redux-test-utils'
-import sinon from 'sinon'
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import { createMockStore } from "redux-test-utils";
+import sinon from "sinon";
 
-describe('ColormapEditorTest.jsx', function() {
+describe("ColormapEditorTest.jsx", function() {
     const props = {
         show: true,
-        close: function(){return true}
-    }
+        close: function() {
+            return true;
+        }
+    };
 
-    const state = { 
+    const state = {
         present: {
             graphics_methods: {
-                boxfill:{
-                    default:{}
+                boxfill: {
+                    default: {}
                 }
             },
             sheets_model: {
                 row_count: 1,
                 col_count: 1,
-                sheets: [{
-                    cells:[[
-                        {
-                            plots: [{
-                                graphics_method_parent: "boxfill",
-                                graphics_method: "default"
-                            }]
-                        }
-                    ]]
-                }],
+                sheets: [
+                    {
+                        cells: [
+                            [
+                                {
+                                    plots: [
+                                        {
+                                            graphics_method_parent: "boxfill",
+                                            graphics_method: "default"
+                                        }
+                                    ]
+                                }
+                            ]
+                        ]
+                    }
+                ],
                 selected_cell_id: "0_0_0",
                 cur_sheet_index: 0
             },
             colormaps: {
-                "viridis":[
+                viridis: [
                     [100, 100, 100, 100], // 3 cells total
                     [70, 70, 70, 100],
-                    [40, 40, 40, 100],
+                    [40, 40, 40, 100]
                 ],
-                "testSelect": [
-                    [0, 0, 0, 100],
-                    [70, 70, 70, 100],
-                    [100, 100, 100, 100],
-                ]
-            },
+                testSelect: [[0, 0, 0, 100], [70, 70, 70, 100], [100, 100, 100, 100]]
+            }
         }
-    }
-    
-    it('renders without exploding', () => {
-        const store = createMockStore(state)
-        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>)
+    };
+
+    it("renders without exploding", () => {
+        const store = createMockStore(state);
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props} />);
         expect(colormap_editor).to.have.lengthOf(1);
     });
 
-    it('handleChange updates color state', () => {
-        const store = createMockStore(state)
-        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>).dive()
+    it("handleChange updates color state", () => {
+        const store = createMockStore(state);
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props} />).dive();
         colormap_editor.setState({
-            current_colormap: [
-                [100, 100, 100, 100],
-                [70, 70, 70, 100],
-                [40, 40, 40, 100]
-            ],
+            current_colormap: [[100, 100, 100, 100], [70, 70, 70, 100], [40, 40, 40, 100]],
             selected_cells_start: 0,
             selected_cells_end: 0
-        })
+        });
         const color = {
             rgb: {
                 r: 0,
                 g: 0,
                 b: 0
             }
-        }
-        colormap_editor.instance().handleChange(color)
-        expect(colormap_editor.state().current_colormap[0][0]).to.equal(color.rgb.r)
-        expect(colormap_editor.state().current_colormap[0][1]).to.equal(color.rgb.g)
-        expect(colormap_editor.state().current_colormap[0][2]).to.equal(color.rgb.b)
-        expect(colormap_editor.state().currentColor.rgb.r).to.equal(color.rgb.r)
-        expect(colormap_editor.state().currentColor.rgb.g).to.equal(color.rgb.g)
-        expect(colormap_editor.state().currentColor.rgb.g).to.equal(color.rgb.b)
+        };
+        colormap_editor.instance().handleChange(color);
+        expect(colormap_editor.state().current_colormap[0][0]).to.equal(color.rgb.r);
+        expect(colormap_editor.state().current_colormap[0][1]).to.equal(color.rgb.g);
+        expect(colormap_editor.state().current_colormap[0][2]).to.equal(color.rgb.b);
+        expect(colormap_editor.state().currentColor.rgb.r).to.equal(color.rgb.r);
+        expect(colormap_editor.state().currentColor.rgb.g).to.equal(color.rgb.g);
+        expect(colormap_editor.state().currentColor.rgb.g).to.equal(color.rgb.b);
     });
 
-    it('Opens and closes the ImportExportModal', () => {
-        const store = createMockStore(state)
-        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>).dive() 
+    it("Opens and closes the ImportExportModal", () => {
+        const store = createMockStore(state);
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props} />).dive();
         // redux is wrapped around this component. use dive to get around it
-        expect(colormap_editor.state().show_import_export_modal).to.be.false
+        expect(colormap_editor.state().show_import_export_modal).to.be.false;
 
-        colormap_editor.instance().openImportExportModal()
-        expect(colormap_editor.state().show_import_export_modal).to.be.true
+        colormap_editor.instance().openImportExportModal();
+        expect(colormap_editor.state().show_import_export_modal).to.be.true;
 
-        colormap_editor.instance().closeImportExportModal()
-        expect(colormap_editor.state().show_import_export_modal).to.be.false
+        colormap_editor.instance().closeImportExportModal();
+        expect(colormap_editor.state().show_import_export_modal).to.be.false;
     });
 
-    it('Opens the new colormap modal', () => {
-        const store = createMockStore(state)
-        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>).dive() 
-        expect(colormap_editor.state().show_new_colormap_modal).to.be.false
-        colormap_editor.instance().handleOpenNewColormapModal()
-        expect(colormap_editor.state().show_new_colormap_modal).to.be.true
+    it("Opens the new colormap modal", () => {
+        const store = createMockStore(state);
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props} />).dive();
+        expect(colormap_editor.state().show_new_colormap_modal).to.be.false;
+        colormap_editor.instance().handleOpenNewColormapModal();
+        expect(colormap_editor.state().show_new_colormap_modal).to.be.true;
     });
 
-    it('handleCellClick selects cells and sets color', () => {
-        const store = createMockStore(state)
-        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>).dive()
-        
-        expect(colormap_editor.state().selected_cells_start).to.equal(-1)
-        expect(colormap_editor.state().selected_cells_end).to.equal(-1)
+    it("handleCellClick selects cells and sets color", () => {
+        const store = createMockStore(state);
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props} />).dive();
 
-        colormap_editor.instance().handleCellClick(2,2)
+        expect(colormap_editor.state().selected_cells_start).to.equal(-1);
+        expect(colormap_editor.state().selected_cells_end).to.equal(-1);
 
-        expect(colormap_editor.state().selected_cells_start).to.equal(2)
-        expect(colormap_editor.state().selected_cells_end).to.equal(2)
-        expect(colormap_editor.state().currentColor.rgb.r).to.equal(102) // colormaps use 0-100, color object uses 0-255
-        expect(colormap_editor.state().currentColor.rgb.g).to.equal(102) // we input 40% which comes out as 102/255
-        expect(colormap_editor.state().currentColor.rgb.b).to.equal(102)
+        colormap_editor.instance().handleCellClick(2, 2);
+
+        expect(colormap_editor.state().selected_cells_start).to.equal(2);
+        expect(colormap_editor.state().selected_cells_end).to.equal(2);
+        expect(colormap_editor.state().currentColor.rgb.r).to.equal(102); // colormaps use 0-100, color object uses 0-255
+        expect(colormap_editor.state().currentColor.rgb.g).to.equal(102); // we input 40% which comes out as 102/255
+        expect(colormap_editor.state().currentColor.rgb.b).to.equal(102);
     });
 
+    it("Loads the selected colormap", () => {
+        const store = createMockStore(state);
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props} />).dive();
 
-    it('Loads the selected colormap', () => {
-        const store = createMockStore(state)
-        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>).dive() 
-
-        colormap_editor.instance().handleSelectColormap("testSelect")
-        expect(colormap_editor.state().current_colormap[0][0]).to.equal(0) // first cell red should be 0
-        expect(colormap_editor.state().current_colormap[1][0]).to.equal(70) // second cell red should be 70
-        expect(colormap_editor.state().current_colormap[2][0]).to.equal(100) // third cell red should be 100
+        colormap_editor.instance().handleSelectColormap("testSelect");
+        expect(colormap_editor.state().current_colormap[0][0]).to.equal(0); // first cell red should be 0
+        expect(colormap_editor.state().current_colormap[1][0]).to.equal(70); // second cell red should be 70
+        expect(colormap_editor.state().current_colormap[2][0]).to.equal(100); // third cell red should be 100
     });
-    
-    it('Deletes a colormap properly', () => {
-        const store = createMockStore(state)
-        const colormap_editor = shallow(<ColormapEditor store={store} {...props}/>).dive()
-        let warn = console.warn
-        console.warn = function(){return} // disable console.warn to prevent unnecessary warnings about vcs being missing
-        const confirm = sinon.stub(global, 'confirm')
-        confirm.returns(true)
+
+    it("Deletes a colormap properly", () => {
+        const store = createMockStore(state);
+        const colormap_editor = shallow(<ColormapEditor store={store} {...props} />).dive();
+        let warn = console.warn;
+        console.warn = function() {
+            return;
+        }; // disable console.warn to prevent unnecessary warnings about vcs being missing
+        const confirm = sinon.stub(global, "confirm");
+        confirm.returns(true);
         global.vcs = {
             removecolormap() {
-                return Promise.resolve()
+                return Promise.resolve();
             }
-        }
+        };
 
-        colormap_editor.instance().handleSelectColormap("testSelect")
-        colormap_editor.instance().handleDeleteColormap("testSelect")
-        expect(colormap_editor.state().selected_colormap_name).to.equal("viridis") // since it is the only colormap left, viridis should be selected
-        for(let cell = 0; cell < 3; cell++){
-            for(let color_index = 0; color_index < 3; color_index++){
-                expect(colormap_editor.state().current_colormap[cell][color_index]).to.equal(state.present.colormaps.viridis[cell][color_index])
+        colormap_editor.instance().handleSelectColormap("testSelect");
+        colormap_editor.instance().handleDeleteColormap("testSelect");
+        expect(colormap_editor.state().selected_colormap_name).to.equal("viridis"); // since it is the only colormap left, viridis should be selected
+        for (let cell = 0; cell < 3; cell++) {
+            for (let color_index = 0; color_index < 3; color_index++) {
+                expect(colormap_editor.state().current_colormap[cell][color_index]).to.equal(state.present.colormaps.viridis[cell][color_index]);
             }
         }
-        console.warn = warn // restore console.warn
-        confirm.restore()
+        console.warn = warn; // restore console.warn
+        confirm.restore();
     });
 
-    it('Blends a colormap properly', () => {
+    it("Blends a colormap properly", () => {
         var blend_state = {
             present: {
                 sheets_model: {
-                    sheets: [
-                        {row_count: 1, col_count: 1}
-                    ],
+                    sheets: [{ row_count: 1, col_count: 1 }],
                     selected_cell_id: "0_0_0",
                     cur_sheet_index: 0
                 },
                 colormaps: {
-                    "viridis":[ // viridis will be loaded by default. Change the values here to something we can blend
+                    viridis: [
+                        // viridis will be loaded by default. Change the values here to something we can blend
                         [0, 0, 0, 100], // 3 cells total
                         [0, 0, 0, 100], // this cell will be blended to [50, 50, 50]
-                        [100, 100, 100, 100],
+                        [100, 100, 100, 100]
                     ]
                 }
             }
-        }
-        const store = createMockStore(blend_state)
-        const colormap_widget = shallow(<ColormapEditor store={store}/>).dive()
+        };
+        const store = createMockStore(blend_state);
+        const colormap_widget = shallow(<ColormapEditor store={store} {...props} />).dive();
         colormap_widget.setState({
             selected_cells_start: 0,
             selected_cells_end: 2
-        })
-        colormap_widget.instance().blendColors()
-        let blended_values = [0, 50, 100]
-        for(let cell = 0; cell < 3; cell++){
-            for(let color_index = 0; color_index < 3; color_index++){
-                expect(colormap_widget.state().current_colormap[cell][color_index]).to.equal(blended_values[cell])
+        });
+        colormap_widget.instance().blendColors();
+        let blended_values = [0, 50, 100];
+        for (let cell = 0; cell < 3; cell++) {
+            for (let color_index = 0; color_index < 3; color_index++) {
+                expect(colormap_widget.state().current_colormap[cell][color_index]).to.equal(blended_values[cell]);
             }
         }
     });
 
-    it('Resets a colormap properly', () => {
-        const store = createMockStore(state)
-        const colormap_widget = shallow(<ColormapEditor store={store}/>).dive()
-        colormap_widget.instance().handleSelectColormap("testSelect")
+    it("Resets a colormap properly", () => {
+        const store = createMockStore(state);
+        const colormap_widget = shallow(<ColormapEditor store={store} {...props} />).dive();
+        colormap_widget.instance().handleSelectColormap("testSelect");
         const color = {
-            rgb:{
+            rgb: {
                 r: 41,
                 g: 41,
-                b: 41,
+                b: 41
             }
-        }
-        colormap_widget.setState({selected_cells_start: 1, selected_cells_end: 1})
-        colormap_widget.instance().handleChange(color)
-        expect(colormap_widget.state().current_colormap[1][0]).to.equal(16)
-        expect(colormap_widget.state().current_colormap[1][1]).to.equal(16)
-        expect(colormap_widget.state().current_colormap[1][2]).to.equal(16)
-        colormap_widget.instance().resetColormap()
-        for(let cell = 0; cell < 3; cell++){
-            for(let color_index = 0; color_index < 3; color_index++){
-                expect(colormap_widget.state().current_colormap[cell][color_index]).to.equal(state.present.colormaps.testSelect[cell][color_index])
+        };
+        colormap_widget.setState({ selected_cells_start: 1, selected_cells_end: 1 });
+        colormap_widget.instance().handleChange(color);
+        expect(colormap_widget.state().current_colormap[1][0]).to.equal(16);
+        expect(colormap_widget.state().current_colormap[1][1]).to.equal(16);
+        expect(colormap_widget.state().current_colormap[1][2]).to.equal(16);
+        colormap_widget.instance().resetColormap();
+        for (let cell = 0; cell < 3; cell++) {
+            for (let color_index = 0; color_index < 3; color_index++) {
+                expect(colormap_widget.state().current_colormap[cell][color_index]).to.equal(state.present.colormaps.testSelect[cell][color_index]);
             }
         }
     });
 
-    it('Helper function for new colormaps calls expected functions', () => {
-        const dummy_cm = [1,2,3]
+    it("Helper function for new colormaps calls expected functions", () => {
+        const dummy_cm = [1, 2, 3];
         global.vcs = {
             createcolormap: sinon.stub().resolves(dummy_cm)
-        }
-        let spy = sinon.spy()
-        const store = createMockStore(state)
-        const colormap_editor = shallow(<ColormapEditor store={store} saveColormap={spy}/>).dive()
-        return colormap_editor.instance().createNewColormapInVcs(dummy_cm, "test").then(()=>{
-            expect(global.vcs.createcolormap.calledWith("test", dummy_cm)).to.be.true
-        },
-        () => {
-            assert(false)
-        })
+        };
+        let spy = sinon.spy();
+        const store = createMockStore(state);
+        const colormap_editor = shallow(<ColormapEditor store={store} saveColormap={spy} {...props} />).dive();
+        return colormap_editor
+            .instance()
+            .createNewColormapInVcs(dummy_cm, "test")
+            .then(
+                () => {
+                    expect(global.vcs.createcolormap.calledWith("test", dummy_cm)).to.be.true;
+                },
+                () => {
+                    assert(false);
+                }
+            );
     });
 
-    it('saves a colormap', () => {
-        const store = createMockStore(state)
-        let dummy_save = sinon.spy()
+    it("saves a colormap", () => {
+        const store = createMockStore(state);
+        let dummy_save = sinon.spy();
         global.vcs = {
             setcolormap: sinon.stub().resolves()
-        }
-        const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save}/>).dive()
-        colormap_widget.setState({current_colormap: [1,2,3]})
-        colormap_widget.setProps({saveColormap: dummy_save}) // 
-        return colormap_widget.instance().saveColormap("name").then(()=>{
-            expect(dummy_save.calledOnce).to.be.true
-            expect(dummy_save.calledWith("name", [1,2,3])).to.be.true
-            // dummy save represents the call to redux to save the colormap
-        },
-        () => { // Should not error. assert false to catch if it does
-            assert(false)
-        })
-    })
-
-    it('rejects gracefully when saving if vcs is not defined', () => {
-        const store = createMockStore(state)
-        let dummy_save = sinon.spy()
-        delete global.vcs
-        const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save}/>).dive()
-        colormap_widget.setState({current_colormap: [1,2,3]})
-        return colormap_widget.instance().saveColormap("name").then(()=>{
-            assert(false)
-        },
-        () => {
-            assert(true)
-        })
+        };
+        const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save} {...props} />).dive();
+        colormap_widget.setState({ current_colormap: [1, 2, 3] });
+        colormap_widget.setProps({ saveColormap: dummy_save }); //
+        return colormap_widget
+            .instance()
+            .saveColormap("name")
+            .then(
+                () => {
+                    expect(dummy_save.calledOnce).to.be.true;
+                    expect(dummy_save.calledWith("name", [1, 2, 3])).to.be.true;
+                    // dummy save represents the call to redux to save the colormap
+                },
+                () => {
+                    // Should not error. assert false to catch if it does
+                    assert(false);
+                }
+            );
     });
 
-    it('rejects a save if no name is given', () => {
-        const store = createMockStore(state)
-        let dummy_save = sinon.spy()
-        delete global.vcs
-        const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save}/>).dive()
-        colormap_widget.setState({current_colormap: [1,2,3]})
-        return colormap_widget.instance().saveColormap("").then(()=>{
-            assert(false)
-        },
-        () => {
-            assert(true)
-        })
+    it("rejects gracefully when saving if vcs is not defined", () => {
+        const store = createMockStore(state);
+        let dummy_save = sinon.spy();
+        let warn = console.warn;
+        console.warn = () => {};
+        delete global.vcs;
+        const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save} {...props} />).dive();
+        colormap_widget.setState({ current_colormap: [1, 2, 3] });
+        return colormap_widget
+            .instance()
+            .saveColormap("name")
+            .then(
+                () => {
+                    assert(false);
+                    console.warn = warn;
+                },
+                () => {
+                    assert(true);
+                    console.warn = warn;
+                }
+            );
     });
 
-    it('Applies a colormap correctly', () => {
+    it("rejects a save if no name is given", () => {
+        const store = createMockStore(state);
+        let dummy_save = sinon.spy();
+        delete global.vcs;
+        const colormap_widget = shallow(<ColormapEditor store={store} saveColormap={dummy_save} {...props} />).dive();
+        colormap_widget.setState({ current_colormap: [1, 2, 3] });
+        return colormap_widget
+            .instance()
+            .saveColormap("")
+            .then(
+                () => {
+                    assert(false);
+                },
+                () => {
+                    assert(true);
+                }
+            );
+    });
+
+    it("Applies a colormap correctly", () => {
         global.vcs = {
-            getcolormapnames: function(){
-                return new Promise((resolve) => {
+            getcolormapnames: function() {
+                return new Promise(resolve => {
                     resolve(["default", "viridis", "testSelect"]);
-                })
+                });
             },
-            setcolormap: function(){
-                return new Promise((resolve) => {
+            setcolormap: function() {
+                return new Promise(resolve => {
                     resolve("");
-                })
+                });
             },
-            createcolormap: function(){
-                return new Promise((resolve) => {
+            createcolormap: function() {
+                return new Promise(resolve => {
                     resolve("");
-                })
+                });
             }
-        }
-        
+        };
+
         let spies = {
             saveColormap: sinon.spy(),
             updateGraphicsMethod: sinon.spy(),
-            applyColormap: sinon.spy(),
-        }
-        const store = createMockStore(state)
-        const colormap_widget = shallow(<ColormapEditor store={store} />).dive()
+            applyColormap: sinon.spy()
+        };
+        const store = createMockStore(state);
+        const colormap_widget = shallow(<ColormapEditor store={store} {...props} />).dive();
         colormap_widget.setProps({
             saveColormap: spies.saveColormap,
             updateGraphicsMethod: spies.updateGraphicsMethod,
-            applyColormap: spies.applyColormap,
-        })
-        return colormap_widget.instance().handleApplyColormap().then(() => {
-            sinon.assert.called(spies.updateGraphicsMethod)
-            sinon.assert.called(spies.applyColormap)
-        })
-    })
+            applyColormap: spies.applyColormap
+        });
+        return colormap_widget
+            .instance()
+            .handleApplyColormap()
+            .then(() => {
+                sinon.assert.called(spies.updateGraphicsMethod);
+                sinon.assert.called(spies.applyColormap);
+            });
+    });
 });

--- a/frontend/test/mocha/components/Modals/ColormapEditor/ImportExportModalTest.jsx
+++ b/frontend/test/mocha/components/Modals/ColormapEditor/ImportExportModalTest.jsx
@@ -1,47 +1,46 @@
 /* globals it, describe, before, beforeEach, */
-var chai = require('chai')
+var chai = require("chai");
 var expect = chai.expect;
-var React = require('react')
+var React = require("react");
 
-import ImportExportModal from '../../../../../src/js/components/modals/ColormapEditor/ImportExportModal.jsx'
-import Enzyme from 'enzyme' 
-import Adapter from 'enzyme-adapter-react-16'
-Enzyme.configure({ adapter: new Adapter() })
-import { shallow } from 'enzyme'
-import sinon from 'sinon'
+import ImportExportModal from "../../../../../src/js/components/modals/ColormapEditor/ImportExportModal.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import sinon from "sinon";
 
+var import_export_modal = shallow(<ImportExportModal show={true} close={() => {}} />);
 
-var import_export_modal = shallow(<ImportExportModal/>)
-
-describe('ImportExportModalTest.jsx', function() {
-    it('renders without exploding', () => {
-        expect(import_export_modal).to.have.lengthOf(1)
+describe("ImportExportModalTest.jsx", function() {
+    it("renders without exploding", () => {
+        expect(import_export_modal).to.have.lengthOf(1);
     });
-    it('Handles importing a file', () => {
+    it("Handles importing a file", () => {
         let mockColormap = {
-            "name": "mockColormap",
-            "colormap":[[100,100,100,100]]
-        }
-        let fakeFile = new Blob([JSON.stringify(mockColormap)], { type: 'text/html' });
-        fakeFile["lastModifiedDate"] = ""
-        fakeFile["name"] = "mockColormapFile"
+            name: "mockColormap",
+            colormap: [[100, 100, 100, 100]]
+        };
+        let fakeFile = new Blob([JSON.stringify(mockColormap)], { type: "text/html" });
+        fakeFile["lastModifiedDate"] = "";
+        fakeFile["name"] = "mockColormapFile";
         let event = {
-            target:{
-                files:[fakeFile]
+            target: {
+                files: [fakeFile]
             }
-        }
-        let stub = sinon.stub(window.FileReader.prototype, 'readAsText').callsFake(function() {
+        };
+        let stub = sinon.stub(window.FileReader.prototype, "readAsText").callsFake(function() {
             let event = {
                 target: {
                     result: JSON.stringify(mockColormap)
                 }
-            }
+            };
             this.onload(event);
         });
-        import_export_modal.instance().handleFileChange(event)
-        expect(import_export_modal.state().importName).to.equal(mockColormap.name)
-        for(let i = 0; i < mockColormap.colormap[0].length; i++){
-            expect(import_export_modal.state().importColormap[0][i]).to.equal(mockColormap.colormap[0][i])
+        import_export_modal.instance().handleFileChange(event);
+        expect(import_export_modal.state().importName).to.equal(mockColormap.name);
+        for (let i = 0; i < mockColormap.colormap[0].length; i++) {
+            expect(import_export_modal.state().importColormap[0][i]).to.equal(mockColormap.colormap[0][i]);
         }
     });
     // it('Creates the correct json for download', () => {
@@ -54,7 +53,7 @@ describe('ImportExportModalTest.jsx', function() {
     //             value: "mockName"
     //         }
     //     }
-         
+
     //     import_export_modal = shallow(<ImportExportModal currentColormap={result.colormap} />)
 
     //     import_export_modal.instance().handleChange(event)

--- a/frontend/test/mocha/components/Modals/EditVariableTest.jsx
+++ b/frontend/test/mocha/components/Modals/EditVariableTest.jsx
@@ -1,104 +1,96 @@
 /* globals it, describe, before, beforeEach, */
-var chai = require('chai')
+var chai = require("chai");
 var expect = chai.expect;
-var React = require('react')
+var React = require("react");
 
-import { PureEditVariable as EditVariable } from '../../../../src/js/components/modals/EditVariable.jsx'
-import Enzyme from 'enzyme' 
-import Adapter from 'enzyme-adapter-react-16'
-Enzyme.configure({ adapter: new Adapter() })
-import { shallow } from 'enzyme'
-import sinon from 'sinon'
-import $ from 'jquery'
+import { PureEditVariable as EditVariable } from "../../../../src/js/components/modals/EditVariable.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import sinon from "sinon";
+import $ from "jquery";
 
 const props = {
     show: true,
     onTryClose: sinon.spy(),
     variables: {
-        "clt": {
+        clt: {
             axisList: ["time", "latitude", "longitude"],
             cdms_var_name: "test",
-            dimension: [
-                { axisName: "time" },
-                { axisName: "latitude" },
-                { axisName: "longitude" }
-            ],
+            dimension: [{ axisName: "time" }, { axisName: "latitude" }, { axisName: "longitude" }],
             path: "dummy/path/test.nc"
         }
     },
     active_variable: "clt",
-    updateVariable: sinon.spy(),
-}
+    updateVariable: sinon.spy()
+};
 
 const dummy_vcs = {
-    variables: function () {
+    variables: function() {
         return Promise.resolve([
             {
-                "clt": {
-                    "gridType": "rectilinear",
-                    "name": "Total cloudiness",
-                    "axisList": ["time", "latitude", "longitude"],
-                    "bounds": null,
-                    "shape": [10, 5, 5],
-                    "lonLat": null,
-                    "units": "%"
-                },
+                clt: {
+                    gridType: "rectilinear",
+                    name: "Total cloudiness",
+                    axisList: ["time", "latitude", "longitude"],
+                    bounds: null,
+                    shape: [10, 5, 5],
+                    lonLat: null,
+                    units: "%"
+                }
             },
             {
-                "longitude": {
-                    "units": "degrees_east",
-                    "shape": [5],
-                    "data": [-180, -175, -170, -165, -160],
-                    "name": "longitude"
+                longitude: {
+                    units: "degrees_east",
+                    shape: [5],
+                    data: [-180, -175, -170, -165, -160],
+                    name: "longitude"
                 },
-                "time": {
-                    "units": "months since 1979-1-1 0",
-                    "shape": [10],
-                    "data": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                    "name": "time"
+                time: {
+                    units: "months since 1979-1-1 0",
+                    shape: [10],
+                    data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                    name: "time"
                 },
-                "latitude": {
-                    "units": "degrees_north",
-                    "shape": [5],
-                    "data": [-90, -86, -82, -78, -74],
-                    "name": "latitude"
-                },
+                latitude: {
+                    units: "degrees_north",
+                    shape: [5],
+                    data: [-90, -86, -82, -78, -74],
+                    name: "latitude"
+                }
             }
-        ])
+        ]);
     }
-}
+};
 
-describe('EditVariableTest.jsx', function () {
-    it('Renders without exploding', () => {
-        global.vcs = dummy_vcs
-        var edit_variable = shallow(<EditVariable {...props} />)
+describe("EditVariableTest.jsx", function() {
+    it("Renders without exploding", () => {
+        global.vcs = dummy_vcs;
+        var edit_variable = shallow(<EditVariable {...props} />);
         expect(edit_variable).to.have.lengthOf(1);
-        let props_off = $.extend(true, { show: false }, props)
-        edit_variable = shallow(<EditVariable {...props_off} />)
+        let props_off = $.extend(true, { show: false }, props);
+        edit_variable = shallow(<EditVariable {...props_off} />);
         expect(edit_variable).to.have.lengthOf(1);
-    })
+    });
 
     it("Handles dimension value changes", () => {
-        const edit_variable = shallow(<EditVariable {...props} />)
+        const edit_variable = shallow(<EditVariable {...props} />);
         edit_variable.setState({
-            dimension: [
-                {axisName: "time"},
-                {axisName: "latitude"},
-                {axisName: "longitude"}
-            ]
-        })
-        edit_variable.instance().handleDimensionValueChange({range: [1, 9], stride: 1}, "time")
-        expect(edit_variable.state().dimension[0].values.range[0]).to.equal(1)
-        expect(edit_variable.state().dimension[0].values.range[1]).to.equal(9)
-        expect(edit_variable).to.have.lengthOf(1)
-    })
+            dimension: [{ axisName: "time" }, { axisName: "latitude" }, { axisName: "longitude" }]
+        });
+        edit_variable.instance().handleDimensionValueChange({ range: [1, 9], stride: 1 }, "time");
+        expect(edit_variable.state().dimension[0].values.range[0]).to.equal(1);
+        expect(edit_variable.state().dimension[0].values.range[1]).to.equal(9);
+        expect(edit_variable).to.have.lengthOf(1);
+    });
 
     it("Saves and closes", () => {
-        const edit_variable = shallow(<EditVariable {...props} />)
-        edit_variable.find('#edit-var-save').simulate("click")
-        expect(props.updateVariable.calledOnce).to.be.true
-        expect(props.onTryClose.calledOnce).to.be.true
-        edit_variable.find('#edit-var-close').simulate("click")
-        expect(props.onTryClose.callCount).to.equal(2)
-    })
+        const edit_variable = shallow(<EditVariable {...props} />);
+        edit_variable.find("#edit-var-save").simulate("click");
+        expect(props.updateVariable.calledOnce).to.be.true;
+        expect(props.onTryClose.calledOnce).to.be.true;
+        edit_variable.find("#edit-var-close").simulate("click");
+        expect(props.onTryClose.callCount).to.equal(2);
+    });
 });

--- a/frontend/test/mocha/components/Modals/EditVariableTest.jsx
+++ b/frontend/test/mocha/components/Modals/EditVariableTest.jsx
@@ -27,7 +27,7 @@ const props = {
 };
 
 const dummy_vcs = {
-    variables: function() {
+    variable: function() {
         return Promise.resolve([
             {
                 clt: {

--- a/frontend/test/mocha/components/Modals/ExportModalTest.jsx
+++ b/frontend/test/mocha/components/Modals/ExportModalTest.jsx
@@ -1,24 +1,33 @@
 /* globals it, describe, before, beforeEach, */
-var chai = require('chai')
+var chai = require("chai");
 var expect = chai.expect;
-var React = require('react')
+var React = require("react");
 
-import ExportModal from '../../../../src/js/components/modals/ExportModal.jsx'
-import Enzyme from 'enzyme' 
-import Adapter from 'enzyme-adapter-react-16'
-Enzyme.configure({ adapter: new Adapter() })
-import { shallow } from 'enzyme'
+import ExportModal from "../../../../src/js/components/modals/ExportModal.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
 
-describe('ExportModalTest.jsx', function() {
-    it('renders without exploding', () => {
-        var export_modal = shallow(<ExportModal/>)
-        expect(export_modal).to.have.lengthOf(1)
+const getProps = () => {
+    return {
+        show: true,
+        close: () => {}
+    };
+};
+
+describe("ExportModalTest.jsx", function() {
+    it("renders without exploding", () => {
+        const props = getProps();
+        var export_modal = shallow(<ExportModal {...props} />);
+        expect(export_modal).to.have.lengthOf(1);
     });
 
-    it('Switch tab sets correct state', () => {
-        var export_modal = shallow(<ExportModal/>)
-        expect(export_modal.state().selected_tab).to.equal(0)
-        export_modal.instance().switchTab(1)
-        expect(export_modal.state().selected_tab).to.equal(1)
+    it("Switch tab sets correct state", () => {
+        const props = getProps();
+        var export_modal = shallow(<ExportModal {...props} />);
+        expect(export_modal.state().selected_tab).to.equal(0);
+        export_modal.instance().switchTab(1);
+        expect(export_modal.state().selected_tab).to.equal(1);
     });
 });

--- a/frontend/test/mocha/components/PlotInspector/PlotInspectorWrapperTest.jsx
+++ b/frontend/test/mocha/components/PlotInspector/PlotInspectorWrapperTest.jsx
@@ -1,29 +1,32 @@
 /* globals it, describe, before, beforeEach, */
-var chai = require('chai')
+var chai = require("chai");
 var expect = chai.expect;
-var React = require('react')
-import { PurePlotInspectorWrapper as PlotInspectorWrapper,
-         mapStateToProps } from '../../../../src/js/components/PlotInspector/PlotInspectorWrapper.jsx'
-import Enzyme from 'enzyme' 
-import Adapter from 'enzyme-adapter-react-16'
-Enzyme.configure({ adapter: new Adapter() })
-import { shallow } from 'enzyme'
-import sinon from 'sinon'
-import PubSub from 'pubsub-js'
-import PubSubEvents from '../../../../src/js/constants/PubSubEvents.js'
-import { toast } from 'react-toastify'
+var React = require("react");
+import {
+    PurePlotInspectorWrapper as PlotInspectorWrapper,
+    mapStateToProps
+} from "../../../../src/js/components/PlotInspector/PlotInspectorWrapper.jsx";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+Enzyme.configure({ adapter: new Adapter() });
+import { shallow } from "enzyme";
+import sinon from "sinon";
+import PubSub from "pubsub-js";
+import PubSubEvents from "../../../../src/js/constants/PubSubEvents.js";
+import { toast } from "react-toastify";
 
-const cell_row = 0
-const cell_col = 0
-const plot_index = 0
+const cell_row = 0;
+const cell_col = 0;
+const plot_index = 0;
 
 function getProps() {
     return {
-        plots: [{
-            variables: [],
-            graphics_method_parent: "boxfill",
-            graphics_method: "default",
-            template: "default"
+        plots: [
+            {
+                variables: [],
+                graphics_method_parent: "boxfill",
+                graphics_method: "default",
+                template: "default"
             }
         ],
         cell_selected: "0_0_0",
@@ -31,202 +34,192 @@ function getProps() {
         cell_col: cell_col,
         all_graphics_methods: {
             boxfill: {
-                "default": {},
-                "polar": {},
-                "quick": {},
+                default: {},
+                polar: {},
+                quick: {}
             },
             vector: {
-                "default": {}
+                default: {}
             },
             isofill: {
-                "polar": {}
+                polar: {}
             }
         },
         variables: ["clt"],
-        graphics_method_types: [
-            "isoline",
-            "boxfill",
-            "isofill",
-            "vector",
-        ],
-        templates: {
-            names: ["default", "quick"],
-        },
+        graphics_method_types: ["isoline", "boxfill", "isofill", "vector"],
+        templates: ["default", "quick"],
         swapGraphicsMethodInPlot: sinon.spy(),
         swapVariableInPlot: sinon.spy(),
         swapTemplateInPlot: sinon.spy(),
-        deleteVariableInPlot: sinon.spy(),
-    }
+        deleteVariableInPlot: sinon.spy()
+    };
 }
 
-describe('PlotInspectorWrapperTest.jsx', function() {
-    it('Renders without exploding', () => {
-        let props = getProps()
-        let wrapper = shallow(<PlotInspectorWrapper {...props}/>)
+describe("PlotInspectorWrapperTest.jsx", function() {
+    it("Renders without exploding", () => {
+        let props = getProps();
+        let wrapper = shallow(<PlotInspectorWrapper {...props} />);
         expect(wrapper).to.have.lengthOf(1);
     });
 
-    it('Handles selecting variable 1', () => {
-        let props = getProps()
-        let wrapper = shallow(<PlotInspectorWrapper {...props}/>)
-        wrapper.instance().handleSelectVar1("clt", plot_index)
-        expect(props.swapVariableInPlot.calledWith(cell_row, cell_col, "clt", plot_index, 0)).to.be.true
+    it("Handles selecting variable 1", () => {
+        let props = getProps();
+        let wrapper = shallow(<PlotInspectorWrapper {...props} />);
+        wrapper.instance().handleSelectVar1("clt", plot_index);
+        expect(props.swapVariableInPlot.calledWith(cell_row, cell_col, "clt", plot_index, 0)).to.be.true;
     });
 
-    it('Handles selecting variable 2', () => {
-        let props = getProps()
-        let wrapper = shallow(<PlotInspectorWrapper {...props}/>)
-        wrapper.instance().handleSelectVar2("clt", plot_index)
-        expect(props.swapVariableInPlot.calledWith(cell_row, cell_col, "clt", plot_index, 1)).to.be.true
+    it("Handles selecting variable 2", () => {
+        let props = getProps();
+        let wrapper = shallow(<PlotInspectorWrapper {...props} />);
+        wrapper.instance().handleSelectVar2("clt", plot_index);
+        expect(props.swapVariableInPlot.calledWith(cell_row, cell_col, "clt", plot_index, 1)).to.be.true;
 
-        wrapper.instance().handleSelectVar2("", 0)
-        expect(props.deleteVariableInPlot.calledWith(cell_row, cell_col, plot_index, 1)).to.be.true
+        wrapper.instance().handleSelectVar2("", 0);
+        expect(props.deleteVariableInPlot.calledWith(cell_row, cell_col, plot_index, 1)).to.be.true;
     });
 
-    it('Handles selecting graphics method type', () => {
-        let props = getProps()
-        let wrapper = shallow(<PlotInspectorWrapper {...props}/>)
-        
-        wrapper.instance().handleSelectGMType("vector", plot_index)
-        expect(props.swapGraphicsMethodInPlot.calledWith(cell_row, cell_col, "vector", "default", plot_index)).to.be.true
+    it("Handles selecting graphics method type", () => {
+        let props = getProps();
+        let wrapper = shallow(<PlotInspectorWrapper {...props} />);
 
-        wrapper.instance().handleSelectGMType("isofill", plot_index)
+        wrapper.instance().handleSelectGMType("vector", plot_index);
+        expect(props.swapGraphicsMethodInPlot.calledWith(cell_row, cell_col, "vector", "default", plot_index)).to.be.true;
+
+        wrapper.instance().handleSelectGMType("isofill", plot_index);
         // if there is no default the first item should be chosen
-        expect(props.swapGraphicsMethodInPlot.calledWith(cell_row, cell_col, "isofill", "polar", plot_index)).to.be.true
-    });
-    
-    it('Handles selecting a graphics method', () => {
-        let props = getProps()
-        let wrapper = shallow(<PlotInspectorWrapper {...props}/>)
-        
-        wrapper.instance().handleSelectGM("boxfill", "quick", plot_index)
-        expect(props.swapGraphicsMethodInPlot.calledWith(cell_row, cell_col, "boxfill", "quick", plot_index)).to.be.true
-    });
-    
-    it('Handles selecting a template', () => {
-        let props = getProps()
-        let wrapper = shallow(<PlotInspectorWrapper {...props}/>)
-
-        wrapper.instance().handleSelectTemplate("default", plot_index)
-        expect(props.swapTemplateInPlot.calledWith(cell_row, cell_col, "default", plot_index)).to.be.true
+        expect(props.swapGraphicsMethodInPlot.calledWith(cell_row, cell_col, "isofill", "polar", plot_index)).to.be.true;
     });
 
-    it('Handles adding a plot', () => {
-        let props = getProps()
-        let addPlot = sinon.spy()
-        let wrapper = shallow(<PlotInspectorWrapper {...props} addPlot={addPlot}/>)
+    it("Handles selecting a graphics method", () => {
+        let props = getProps();
+        let wrapper = shallow(<PlotInspectorWrapper {...props} />);
 
-        wrapper.instance().handleAddPlot()
-        expect(addPlot.callCount).to.equal(1)
-        expect(addPlot.calledWith(null, null, null, null, 0, 0))
-    });
-    
-    it('Calls prop to handle deleting plots', () => {
-        let props = getProps()
-        let deletePlot = sinon.spy()
-        let wrapper = shallow(<PlotInspectorWrapper {...props} deletePlot={deletePlot}/>)
-
-        wrapper.instance().handleDeletePlot()
-        expect(deletePlot.callCount).to.equal(1)
+        wrapper.instance().handleSelectGM("boxfill", "quick", plot_index);
+        expect(props.swapGraphicsMethodInPlot.calledWith(cell_row, cell_col, "boxfill", "quick", plot_index)).to.be.true;
     });
 
-    it('handleClearCell publishes a clear event', () => {
-        const props = getProps()
-        const wrapper = shallow(<PlotInspectorWrapper {...props}/>)
-        let spy = sinon.spy()
+    it("Handles selecting a template", () => {
+        let props = getProps();
+        let wrapper = shallow(<PlotInspectorWrapper {...props} />);
+
+        wrapper.instance().handleSelectTemplate("default", plot_index);
+        expect(props.swapTemplateInPlot.calledWith(cell_row, cell_col, "default", plot_index)).to.be.true;
+    });
+
+    it("Handles adding a plot", () => {
+        let props = getProps();
+        let addPlot = sinon.spy();
+        let wrapper = shallow(<PlotInspectorWrapper {...props} addPlot={addPlot} />);
+
+        wrapper.instance().handleAddPlot();
+        expect(addPlot.callCount).to.equal(1);
+        expect(addPlot.calledWith(null, null, null, null, 0, 0));
+    });
+
+    it("Calls prop to handle deleting plots", () => {
+        let props = getProps();
+        let deletePlot = sinon.spy();
+        let wrapper = shallow(<PlotInspectorWrapper {...props} deletePlot={deletePlot} />);
+
+        wrapper.instance().handleDeletePlot();
+        expect(deletePlot.callCount).to.equal(1);
+    });
+
+    it("handleClearCell publishes a clear event", () => {
+        const props = getProps();
+        const wrapper = shallow(<PlotInspectorWrapper {...props} />);
+        let spy = sinon.spy();
         let clock = sinon.useFakeTimers();
         PubSub.clearAllSubscriptions();
-        PubSub.subscribe(PubSubEvents.clear_canvas, spy)
-        wrapper.instance().handleClearCell()
-        clock.tick(1) // publish is async. We manually tick here to make sure it runs before testing
-        expect(spy.calledOnce).to.be.true
-        clock.restore()
+        PubSub.subscribe(PubSubEvents.clear_canvas, spy);
+        wrapper.instance().handleClearCell();
+        clock.tick(1); // publish is async. We manually tick here to make sure it runs before testing
+        expect(spy.calledOnce).to.be.true;
+        clock.restore();
     });
 
-    it('Clear button toasts when a cell is not selected', () => {
+    it("Clear button toasts when a cell is not selected", () => {
         // clear should not be called if no cells are selected
-        let props = getProps()
-        props.cell_selected = "-1_-1_-1"
-        const wrapper = shallow(<PlotInspectorWrapper {...props}/>)
+        let props = getProps();
+        props.cell_selected = "-1_-1_-1";
+        const wrapper = shallow(<PlotInspectorWrapper {...props} />);
         let clock = sinon.useFakeTimers();
-        sinon.stub(toast, "info")
-        let spy = sinon.spy()
-        PubSub.subscribe(PubSubEvents.clear_canvas, spy)
-        wrapper.instance().handleClearCell()
-        clock.tick(1) // publish is async. We manually tick here to make sure it runs before testing
-        expect(toast.info.calledOnce).to.be.true
-        expect(spy.calledOnce).to.be.false
-        clock.restore()
+        sinon.stub(toast, "info");
+        let spy = sinon.spy();
+        PubSub.subscribe(PubSubEvents.clear_canvas, spy);
+        wrapper.instance().handleClearCell();
+        clock.tick(1); // publish is async. We manually tick here to make sure it runs before testing
+        expect(toast.info.calledOnce).to.be.true;
+        expect(spy.calledOnce).to.be.false;
+        clock.restore();
     });
 
-    it('Colormap editor opens and closes', () => {
-        const props = getProps()
-        const wrapper = shallow(<PlotInspectorWrapper {...props} />)
-        expect(wrapper.instance().state.show_colormap_editor).to.be.false
-        wrapper.instance().handleOpenColormapEditor()
-        expect(wrapper.instance().state.show_colormap_editor).to.be.true
-        wrapper.instance().handleCloseColormapEditor()
-        expect(wrapper.instance().state.show_colormap_editor).to.be.false
+    it("Colormap editor opens and closes", () => {
+        const props = getProps();
+        const wrapper = shallow(<PlotInspectorWrapper {...props} />);
+        expect(wrapper.instance().state.show_colormap_editor).to.be.false;
+        wrapper.instance().handleOpenColormapEditor();
+        expect(wrapper.instance().state.show_colormap_editor).to.be.true;
+        wrapper.instance().handleCloseColormapEditor();
+        expect(wrapper.instance().state.show_colormap_editor).to.be.false;
     });
 
-    it('Maps state to props with a cell selected', () => {
+    it("Maps state to props with a cell selected", () => {
         const plot_value = {
             variables: [],
             graphics_method_parent: "boxfill",
             graphics_method: "default",
             template: "default"
-        }
+        };
         const state = {
-            present:{
+            present: {
                 graphics_methods: {
                     boxfill: {
-                        default:{}
+                        default: {}
                     },
                     isofill: {
-                        default:{}
+                        default: {}
                     }
                 },
                 variables: {
-                    clt: {},
+                    clt: {}
                 },
-                templates: [
-                    "default",
-                    "quick"
-                ],
+                templates: ["default", "quick"],
                 sheets_model: {
                     selected_cell_id: "0_0_0",
-                    sheets: [{
-                        name: "Sheet",
-                        col_count: 1,
-                        row_count: 1,
-                        selected_cell_indices: [
-                            [-1, -1]
-                        ],
-                        cells: [
-                            [{
-                                plot_being_edited: 0,
-                                plots: [
-                                    plot_value
+                    sheets: [
+                        {
+                            name: "Sheet",
+                            col_count: 1,
+                            row_count: 1,
+                            selected_cell_indices: [[-1, -1]],
+                            cells: [
+                                [
+                                    {
+                                        plot_being_edited: 0,
+                                        plots: [plot_value]
+                                    }
                                 ]
-                            }]
-                        ],
-                        sheet_index: 0
-                    }]
+                            ],
+                            sheet_index: 0
+                        }
+                    ]
                 }
             }
-        }
-        
-        const obj = mapStateToProps(state)
+        };
+
+        const obj = mapStateToProps(state);
         expect(obj.all_graphics_methods).to.deep.equal({
-            boxfill: {default:{}},
-            isofill: {default:{}}
-        })
-        expect(obj.cell_row).to.equal(0)
-        expect(obj.cell_col).to.equal(0)
-        expect(obj.cell_selected).to.equal("0_0_0")
-        expect(obj.graphics_method_types).to.deep.equal(["boxfill", "isofill"])
-        expect(obj.plots[0]).to.deep.equal(plot_value)
-        expect(obj.templates).to.deep.equal(["default", "quick"])
-        expect(obj.variables).to.deep.equal(["clt"])
+            boxfill: { default: {} },
+            isofill: { default: {} }
+        });
+        expect(obj.cell_row).to.equal(0);
+        expect(obj.cell_col).to.equal(0);
+        expect(obj.cell_selected).to.equal("0_0_0");
+        expect(obj.graphics_method_types).to.deep.equal(["boxfill", "isofill"]);
+        expect(obj.plots[0]).to.deep.equal(plot_value);
+        expect(obj.templates).to.deep.equal(["default", "quick"]);
+        expect(obj.variables).to.deep.equal(["clt"]);
     });
 });

--- a/frontend/test/mocha/constants/ActionsTest.js
+++ b/frontend/test/mocha/constants/ActionsTest.js
@@ -1,349 +1,352 @@
 /* globals it, describe, before, beforeEach, */
-var chai = require('chai');
+var chai = require("chai");
 var expect = chai.expect;
-import Actions from '../../../src/js/constants/Actions.js'
+import Actions from "../../../src/js/constants/Actions.js";
 
-describe('ActionsTest.js', function() {
-    it('rowCountChanged works', () => {
-        let result = Actions.rowCountChanged(2)
+describe("ActionsTest.js", function() {
+    it("rowCountChanged works", () => {
+        let result = Actions.rowCountChanged(2);
         let expected = {
-            type: 'ROW_COUNT_CHANGED',
+            type: "ROW_COUNT_CHANGED",
             count: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('colCountChanged works', () => {
-        let result = Actions.colCountChanged(2)
+    it("colCountChanged works", () => {
+        let result = Actions.colCountChanged(2);
         let expected = {
-            type: 'COL_COUNT_CHANGED',
+            type: "COL_COUNT_CHANGED",
             count: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('addSheet works', () => {
-        let result = Actions.addSheet()
+    it("addSheet works", () => {
+        let result = Actions.addSheet();
         let expected = {
-            type: 'ADD_SHEET',
-        }
-        expect(result).to.deep.equal(expected)
+            type: "ADD_SHEET"
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('removeSheet works', () => {
-        let result = Actions.removeSheet(2)
+    it("removeSheet works", () => {
+        let result = Actions.removeSheet(2);
         let expected = {
-            type: 'REMOVE_SHEET',
+            type: "REMOVE_SHEET",
             sheet_index: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('changeCurSheetIndex works', () => {
-        let result = Actions.changeCurSheetIndex(2)
+    it("changeCurSheetIndex works", () => {
+        let result = Actions.changeCurSheetIndex(2);
         let expected = {
-            type: 'CHANGE_CUR_SHEET_INDEX',
+            type: "CHANGE_CUR_SHEET_INDEX",
             index: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('changePlot works', () => {
-        let result = Actions.changePlot(2)
+    it("changePlot works", () => {
+        let result = Actions.changePlot(2);
         let expected = {
-            type: 'CHANGE_PLOT',
+            type: "CHANGE_PLOT",
             value: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('changePlotVar works', () => {
-        let result = Actions.changePlotVar("variable", 2)
+    it("changePlotVar works", () => {
+        let result = Actions.changePlotVar("variable", 2);
         let expected = {
-            type: 'CHANGE_PLOT_VAR',
+            type: "CHANGE_PLOT_VAR",
             var_being_changed: "variable",
             value: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('changePlotGM works', () => {
-        let result = Actions.changePlotGM({}, "newValue")
+    it("changePlotGM works", () => {
+        let result = Actions.changePlotGM({}, "newValue");
         let expected = {
-            type: 'CHANGE_PLOT_GM',
+            type: "CHANGE_PLOT_GM",
             graphics_method_parent: "newValue"
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
 
-        result = Actions.changePlotGM(undefined, "newValue")
+        result = Actions.changePlotGM(undefined, "newValue");
         expected = {
-            type: 'CHANGE_PLOT_GM',
+            type: "CHANGE_PLOT_GM",
             graphics_method: "newValue"
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('changePlotTemplate works', () => {
-        let result = Actions.changePlotTemplate(2)
+    it("changePlotTemplate works", () => {
+        let result = Actions.changePlotTemplate(2);
         let expected = {
-            type: 'CHANGE_PLOT_TEMPLATE',
+            type: "CHANGE_PLOT_TEMPLATE",
             value: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('initializeTemplateValues works', () => {
-        let result = Actions.initializeTemplateValues([{name: "template1"}, {name: "template2"}])
+    it("initializeTemplateValues works", () => {
+        let result = Actions.initializeTemplateValues([{ name: "template1" }, { name: "template2" }]);
         let expected = {
-            type: 'INITIALIZE_TEMPLATE_VALUES',
-            templates: [{name: "template1"}, {name: "template2"}]
-        }
-        expect(result).to.deep.equal(expected)
+            type: "INITIALIZE_TEMPLATE_VALUES",
+            templates: [{ name: "template1" }, { name: "template2" }]
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('initializeGraphicsMethodsValues works', () => {
-        let result = Actions.initializeGraphicsMethodsValues("gm")
+    it("initializeGraphicsMethodsValues works", () => {
+        let result = Actions.initializeGraphicsMethodsValues("gm");
         let expected = {
-            type: 'INITIALIZE_GRAPHICS_METHODS_VALUES',
+            type: "INITIALIZE_GRAPHICS_METHODS_VALUES",
             graphics_methods: "gm"
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('selectCell works', () => {
-        let result = Actions.selectCell(1)
+    it("selectCell works", () => {
+        let result = Actions.selectCell(1);
         let expected = {
-            type: 'SELECT_CELL',
+            type: "SELECT_CELL",
             cell_id: 1
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('deselectCell works', () => {
-        let result = Actions.deselectCell(1)
+    it("deselectCell works", () => {
+        let result = Actions.deselectCell(1);
         let expected = {
-            type: 'DESELECT_CELL',
-        }
-        expect(result).to.deep.equal(expected)
+            type: "DESELECT_CELL"
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('updateSelectedCells works', () => {
-        let result = Actions.updateSelectedCells([1,2])
+    it("updateSelectedCells works", () => {
+        let result = Actions.updateSelectedCells([1, 2]);
         let expected = {
-            type: 'UPDATE_SELECTED_CELLS',
-            selected_cells: [1,2]
-        }
-        expect(result).to.deep.equal(expected)
+            type: "UPDATE_SELECTED_CELLS",
+            selected_cells: [1, 2]
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('moveColumn works', () => {
-        let result = Actions.moveColumn(1, 2, 3)
+    it("moveColumn works", () => {
+        let result = Actions.moveColumn(1, 2, 3);
         let expected = {
-            type: 'MOVE_COLUMN',
+            type: "MOVE_COLUMN",
             dragged_index: 1,
             dropped_index: 2,
             position: 3
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('moveRow works', () => {
-        let result = Actions.moveRow(1, 2, 3)
+    it("moveRow works", () => {
+        let result = Actions.moveRow(1, 2, 3);
         let expected = {
-            type: 'MOVE_ROW',
+            type: "MOVE_ROW",
             dragged_index: 1,
             dropped_index: 2,
             position: 3
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('clearCell works', () => {
-        let result = Actions.clearCell(1, 2)
+    it("clearCell works", () => {
+        let result = Actions.clearCell(1, 2);
         let expected = {
-            type: 'CLEAR_CELL',
+            type: "CLEAR_CELL",
             row: 1,
             col: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('addPlot works', () => {
-        let result = Actions.addPlot("variable", "graphics_method_parent", "graphics_method", "template", 1, 2)
+    it("addPlot works", () => {
+        let result = Actions.addPlot("variable", "graphics_method_parent", "graphics_method", "template", 1, 2);
         let expected = {
-            type: 'ADD_PLOT',
+            type: "ADD_PLOT",
             variable: "variable",
             graphics_method_parent: "graphics_method_parent",
             graphics_method: "graphics_method",
             template: "template",
             row: 1,
             col: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('deletePlot works', () => {
-        let result = Actions.deletePlot(0, 1, 2)
+    it("deletePlot works", () => {
+        let result = Actions.deletePlot(0, 1, 2);
         let expected = {
-            type: 'DELETE_PLOT',
+            type: "DELETE_PLOT",
             row: 0,
             col: 1,
             index: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('swapVariableInPlot works', () => {
-        let result = Actions.swapVariableInPlot("value", 1, 2, 3, "var_being_changed")
+    it("swapVariableInPlot works", () => {
+        let result = Actions.swapVariableInPlot("value", 1, 2, 3, "var_being_changed");
         let expected = {
-            type: 'CHANGE_PLOT_VAR',
+            type: "CHANGE_PLOT_VAR",
             value: "value",
             row: 1,
             col: 2,
             plot_index: 3,
             var_being_changed: "var_being_changed"
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('deleteVariableInPlot works', () => {
-        let result = Actions.deleteVariableInPlot(1, 2, 3, 4)
+    it("deleteVariableInPlot works", () => {
+        let result = Actions.deleteVariableInPlot(1, 2, 3, 4);
         let expected = {
-            type: 'DELETE_PLOT_VAR',
+            type: "DELETE_PLOT_VAR",
             row: 1,
             col: 2,
             plot_index: 3,
             var_index: 4
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('swapGraphicsMethodInPlot works', () => {
-        let result = Actions.swapGraphicsMethodInPlot("graphics_method_parent", "graphics_method", 1, 2, 3)
+    it("swapGraphicsMethodInPlot works", () => {
+        let result = Actions.swapGraphicsMethodInPlot("graphics_method_parent", "graphics_method", 1, 2, 3);
         let expected = {
-            type: 'CHANGE_PLOT_GM',
+            type: "CHANGE_PLOT_GM",
             graphics_method_parent: "graphics_method_parent",
             graphics_method: "graphics_method",
             row: 1,
             col: 2,
             plot_index: 3
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('swapTemplateInPlot works', () => {
-        let result = Actions.swapTemplateInPlot("value", 1, 2, 3)
+    it("swapTemplateInPlot works", () => {
+        let result = Actions.swapTemplateInPlot("value", 1, 2, 3);
         let expected = {
-            type: 'CHANGE_PLOT_TEMPLATE',
+            type: "CHANGE_PLOT_TEMPLATE",
             value: "value",
             row: 1,
             col: 2,
-            plot_index: 3,
-        }
-        expect(result).to.deep.equal(expected)
+            plot_index: 3
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('shiftSheet works', () => {
-        let result = Actions.shiftSheet(1, 2)
+    it("shiftSheet works", () => {
+        let result = Actions.shiftSheet(1, 2);
         let expected = {
-            type: 'SHIFT_SHEET',
+            type: "SHIFT_SHEET",
             old_position: 1,
             new_position: 2
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('loadVariables works', () => {
-        let result = Actions.loadVariables(["var1", "var2", "var3"])
+    it("loadVariables works", () => {
+        let result = Actions.loadVariables(["var1", "var2", "var3"]);
         let expected = {
-            type: 'LOAD_VARIABLES',
+            type: "LOAD_VARIABLES",
             var_list: ["var1", "var2", "var3"]
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('updateVariable works', () => {
-        let dimensions = [{values:[1,2]}, {values: [3,4]}]
-        let no_tranforms_result = Actions.updateVariable("name", dimensions)
+    it("updateVariable works", () => {
+        let dimensions = [{ values: [1, 2] }, { values: [3, 4] }];
+        let axis_list = ["latitude", "longitude"];
+        let no_tranforms_result = Actions.updateVariable("name", axis_list, dimensions);
         let expected = {
-            type: 'UPDATE_VARIABLE',
+            type: "UPDATE_VARIABLE",
             name: "name",
+            axis_list: axis_list,
             dimensions: dimensions,
             transforms: {}
-        }
-        expect(no_tranforms_result).to.deep.equal(expected)
+        };
+        expect(no_tranforms_result).to.deep.equal(expected);
 
-        let transforms = {latitude: "avg"}
-        let with_transforms_result = Actions.updateVariable("name", dimensions, transforms)
+        let transforms = { latitude: "avg" };
+        let with_transforms_result = Actions.updateVariable("name", axis_list, dimensions, transforms);
         expected = {
-            type: 'UPDATE_VARIABLE',
+            type: "UPDATE_VARIABLE",
             name: "name",
+            axis_list: axis_list,
             dimensions: dimensions,
-            transforms: {latitude: "avg"}
-        }
-        expect(with_transforms_result).to.deep.equal(expected)
+            transforms: { latitude: "avg" }
+        };
+        expect(with_transforms_result).to.deep.equal(expected);
     });
 
-    it('updateGraphicsMethod works', () => {
-        let result = Actions.updateGraphicsMethod("graphics_method")
+    it("updateGraphicsMethod works", () => {
+        let result = Actions.updateGraphicsMethod("graphics_method");
         let expected = {
-            type: 'UPDATE_GRAPHICS_METHOD',
+            type: "UPDATE_GRAPHICS_METHOD",
             graphics_method: "graphics_method"
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('initializeColormaps works', () => {
-        let result = Actions.initializeColormaps(["map1", "map2"])
+    it("initializeColormaps works", () => {
+        let result = Actions.initializeColormaps(["map1", "map2"]);
         let expected = {
-            type: 'INITIALIZE_COLORMAPS',
+            type: "INITIALIZE_COLORMAPS",
             colormaps: ["map1", "map2"]
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('initializeDefaultMethods works', () => {
-        let result = Actions.initializeDefaultMethods("defaults")
+    it("initializeDefaultMethods works", () => {
+        let result = Actions.initializeDefaultMethods("defaults");
         let expected = {
-            type: 'INITIALIZE_DEFAULT_METHODS',
+            type: "INITIALIZE_DEFAULT_METHODS",
             defaultmethods: "defaults"
-        }
-        expect(result).to.deep.equal(expected)
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('updateTemplate works', () => {
-        let result = Actions.updateTemplate("template")
+    it("updateTemplate works", () => {
+        let result = Actions.updateTemplate("template");
         let expected = {
-            type: 'UPDATE_TEMPLATE',
-            template: "template" 
-        }
-        expect(result).to.deep.equal(expected)
+            type: "UPDATE_TEMPLATE",
+            template: "template"
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('saveColormap works', () => {
-        let result = Actions.saveColormap("colormap")
+    it("saveColormap works", () => {
+        let result = Actions.saveColormap("colormap");
         let expected = {
-            type: 'SAVE_COLORMAP',
-            colormap: "colormap" 
-        }
-        expect(result).to.deep.equal(expected)
+            type: "SAVE_COLORMAP",
+            colormap: "colormap"
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('deleteColormap works', () => {
-        let result = Actions.deleteColormap("name")
+    it("deleteColormap works", () => {
+        let result = Actions.deleteColormap("name");
         let expected = {
-            type: 'DELETE_COLORMAP',
-            name: "name" 
-        }
-        expect(result).to.deep.equal(expected)
+            type: "DELETE_COLORMAP",
+            name: "name"
+        };
+        expect(result).to.deep.equal(expected);
     });
 
-    it('removeVariable works', () => {
-        let result = Actions.removeVariable("name")
+    it("removeVariable works", () => {
+        let result = Actions.removeVariable("name");
         let expected = {
-            type: 'REMOVE_VARIABLE',
-            name: "name" 
-        }
-        expect(result).to.deep.equal(expected)
+            type: "REMOVE_VARIABLE",
+            name: "name"
+        };
+        expect(result).to.deep.equal(expected);
     });
 });

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
   package_data={"vcdat": ["resources/" + f for f in os.listdir("backend/vcdat/resources") if f[0] != "."]},
   scripts=["scripts/vcdat", "scripts/check_vcdat_update.py"],
   extras_require={
-      'test':  ["pytest", "pytest-cov"],
+      'test':  ["pytest", "pytest-cov", "selenium"],
   }
 )


### PR DESCRIPTION
Adds a prototype version of the calculator.
It supports basic arithmetic operators and regriding to start with. 
Much like the old calculator in UVCDAT, it will automatically suggest new variable names, but these can be overwritten by the user.

The interface is drag and drop for variables, and is point and click/hotkeys for numbers and basic operators. 

This PR requires the newest version of vcs-js to function due to changes in the vcs-js api necessitated by calculator. 