### PR TITLE
Export Plot Implemented

### DIFF
--- a/frontend/src/js/components/Canvas.jsx
+++ b/frontend/src/js/components/Canvas.jsx
@@ -208,7 +208,7 @@ Canvas.propTypes = {
     col: PropTypes.number,
     selected_cell_id: PropTypes.string,
     cell_id: PropTypes.string,
-    can_plot: PropTypes.bool
+    can_plot: PropTypes.bool,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/frontend/src/js/components/PlotInspector/PlotInspectorWrapper.jsx
+++ b/frontend/src/js/components/PlotInspector/PlotInspectorWrapper.jsx
@@ -136,7 +136,7 @@ class PlotInspectorWrapper extends React.Component {
                     handleOpenExportModal={this.handleOpenExportModal}
                     handleOpenCalculator={this.handleOpenCalculator}
                 />
-                {this.state.show_export_modal && <ExportModal variables={this.props.variables} plots={this.props.plots} show={this.state.show_export_modal} close={this.handleCloseExportModal} />}
+                {this.state.show_export_modal && <ExportModal show={this.state.show_export_modal} close={this.handleCloseExportModal} />}
                 {this.state.show_calculator && <Calculator startTour={this.props.startTour} show={this.state.show_calculator} close={this.handleCloseCalculator} />}
             </div>
         );

--- a/frontend/src/js/components/PlotInspector/PlotInspectorWrapper.jsx
+++ b/frontend/src/js/components/PlotInspector/PlotInspectorWrapper.jsx
@@ -136,7 +136,7 @@ class PlotInspectorWrapper extends React.Component {
                     handleOpenExportModal={this.handleOpenExportModal}
                     handleOpenCalculator={this.handleOpenCalculator}
                 />
-                {this.state.show_export_modal && <ExportModal show={this.state.show_export_modal} close={this.handleCloseExportModal} />}
+                {this.state.show_export_modal && <ExportModal variables={this.props.variables} plots={this.props.plots} show={this.state.show_export_modal} close={this.handleCloseExportModal} />}
                 {this.state.show_calculator && <Calculator startTour={this.props.startTour} show={this.state.show_calculator} close={this.handleCloseCalculator} />}
             </div>
         );

--- a/frontend/src/js/components/modals/CachedFiles/CachedFiles.jsx
+++ b/frontend/src/js/components/modals/CachedFiles/CachedFiles.jsx
@@ -77,8 +77,8 @@ CachedFiles.propTypes = {
     show: PropTypes.bool.isRequired,
     startTour: PropTypes.func,
     onTryClose: PropTypes.func.isRequired,
-    hasError: PropTypes.bool.isRequired,
-    handleError: PropTypes.func.isRequired
+    hasError: PropTypes.bool,
+    handleError: PropTypes.func
 }
 
 export default CachedFiles

--- a/frontend/src/js/components/modals/ExportModal.jsx
+++ b/frontend/src/js/components/modals/ExportModal.jsx
@@ -38,7 +38,7 @@ class ExportModal extends Component {
                     <TabBar tabs={this.state.tabs} selected_tab={this.state.selected_tab} switchTab={this.switchTab}/>
                     <hr/>
                     {
-                        this.state.selected_tab === 1 ? "Not yet implemented" : <SavePlot />
+                        this.state.selected_tab === 1 ? "Not yet implemented" : <SavePlot variables={this.props.variables} plots={this.props.plots} />
                     }
                 </Modal.Body>
                 <Modal.Footer>
@@ -53,6 +53,9 @@ class ExportModal extends Component {
 ExportModal.propTypes = {
     show: PropTypes.bool.isRequired,
     close: PropTypes.func.isRequired,
+    // Added for screenshot testing
+    plots: PropTypes.array,
+    variables: PropTypes.array,
 }
 
 export default ExportModal

--- a/frontend/src/js/components/modals/ExportModal.jsx
+++ b/frontend/src/js/components/modals/ExportModal.jsx
@@ -7,11 +7,18 @@ class ExportModal extends Component {
 
     constructor(props) {
         super(props);
+        
+        this.minWidth = 512;
+        this.minHeight = 512;
+        this.maxWidth = 4096;
+        this.maxHeight = 4096;
+
         this.state = {
             exportWidth: 1024,
             exportHeight: 768,
             exportType: 'png'
         }
+        
         this.handleChangeExt = this.handleChangeExt.bind(this);
         this.handleDimensionUpdate = this.handleDimensionUpdate.bind(this);
         this.handleDimensionChange = this.handleDimensionChange.bind(this);
@@ -59,11 +66,11 @@ class ExportModal extends Component {
                         <input
                             name="widthInput"
                             type="number"
-                            min="512"
-                            max="4096"
+                            min={this.minWidth}
+                            max={this.maxWidth}
                             style={{width: "150px", float: "left"}}
                             value={this.state.exportWidth}
-                            pattern="[0-9]{5}"
+                            pattern="[0-9]"
                             className="form-control"
                             placeholder="width"
                             onChange={(e) => this.handleDimensionChange(e,"exportWidth")}
@@ -73,11 +80,11 @@ class ExportModal extends Component {
                         <input
                             name="heightInput"
                             type="number"
-                            min="512"
-                            max="4096"
+                            min={this.minHeight}
+                            max={this.maxHeight}
                             style={{width: "150px", float: "left"}}
                             value={this.state.exportHeight}
-                            pattern="[0-9]{5}"
+                            pattern="[0-9]"
                             className="form-control"
                             placeholder="height"
                             onChange={(e) => this.handleDimensionChange(e,"exportHeight")}

--- a/frontend/src/js/components/modals/ExportModal.jsx
+++ b/frontend/src/js/components/modals/ExportModal.jsx
@@ -1,31 +1,49 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Modal, Button } from 'react-bootstrap'
-import TabBar from '../TabBar/TabBar.jsx'
 import SavePlot from './SavePlot/SavePlot.jsx'
 
 class ExportModal extends Component {
+
     constructor(props) {
         super(props);
         this.state = {
-            tabs: [
-                {
-                    id: "plot",
-                    display_name: "Plots",
-                },
-                {
-                    id: "vcs",
-                    display_name: "Vcs",
-                    disabled: true,
-                },
-            ],
-            selected_tab: 0
+            exportWidth: 1024,
+            exportHeight: 768,
+            exportType: 'png'
         }
-        this.switchTab = this.switchTab.bind(this)
+        this.handleChangeExt = this.handleChangeExt.bind(this);
+        this.handleDimensionUpdate = this.handleDimensionUpdate.bind(this);
+        this.handleDimensionChange = this.handleDimensionChange.bind(this);
+        this.handleDimensionExit = this.handleDimensionExit.bind(this);
     }
 
-    switchTab(index){
-        this.setState({selected_tab: index})
+    handleChangeExt(type){
+        this.setState({exportType: type});
+    }
+
+    handleDimensionUpdate(dimensions){
+        this.setState({exportWidth: dimensions[0], exportHeight: dimensions[1]});
+    }
+
+    handleDimensionChange(e, dim){
+        if (!e.target.validity.badInput) {
+            let value = Number(e.target.value);
+            this.setState({[dim]: value});
+        }
+    }
+
+    handleDimensionExit(e, dim){
+        if (!e.target.validity.badInput) {
+            let value = Number(e.target.value);
+            if(e.target.validity.rangeOverflow){
+                value = Number(e.target.max);
+            }
+            else if(e.target.validity.rangeUnderflow){
+                value = Number(e.target.min);
+            }
+            this.setState({[dim]: value});
+        }
     }
 
     render(){
@@ -35,11 +53,73 @@ class ExportModal extends Component {
                     <Modal.Title>Export</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                    <TabBar tabs={this.state.tabs} selected_tab={this.state.selected_tab} switchTab={this.switchTab}/>
-                    <hr/>
-                    {
-                        this.state.selected_tab === 1 ? "Not yet implemented" : <SavePlot />
-                    }
+                    <form>
+                        <label>Plot Export Dimensions</label><br />
+                        <label htmlFor="widthInput" style={{float: "left", margin: "5px"}} >Width: </label>
+                        <input
+                            name="widthInput"
+                            type="number"
+                            min="512"
+                            max="4096"
+                            style={{width: "150px", float: "left"}}
+                            value={this.state.exportWidth}
+                            pattern="[0-9]{5}"
+                            className="form-control"
+                            placeholder="width"
+                            onChange={(e) => this.handleDimensionChange(e,"exportWidth")}
+                            onBlur={(e) => this.handleDimensionExit(e,"exportWidth")}
+                        />
+                        <label htmlFor="heightInput" style={{float: "left", margin: "5px"}} >Height: </label>
+                        <input
+                            name="heightInput"
+                            type="number"
+                            min="512"
+                            max="4096"
+                            style={{width: "150px", float: "left"}}
+                            value={this.state.exportHeight}
+                            pattern="[0-9]{5}"
+                            className="form-control"
+                            placeholder="height"
+                            onChange={(e) => this.handleDimensionChange(e,"exportHeight")}
+                            onBlur={(e) => this.handleDimensionExit(e,"exportHeight")}
+                        />
+                        <label htmlFor="ext" style={{float: "left", margin: "5px"}} >Export Type: </label>
+                        <label style={{float: "left", margin: "5px"}}> PNG 
+                            <input 
+                                type="radio"
+                                name="ext"
+                                value="png" 
+                                checked={this.state.exportType==='png'}
+                                onChange={(e) => this.handleChangeExt(e.target.value)}
+                            />
+                        </label>
+                        <label style={{float: "left", margin: "5px"}}> PDF 
+                            <input 
+                                type="radio"
+                                name="ext"
+                                value="pdf" 
+                                checked={this.state.exportType==='pdf'}
+                                onChange={(e) => this.handleChangeExt(e.target.value)}
+                            />
+                        </label>
+                        <label style={{float: "left", margin: "5px"}}> SVG 
+                            <input
+                                type="radio"
+                                name="ext"
+                                value="svg" 
+                                checked={this.state.exportType==='svg'}
+                                onChange={(e) => this.handleChangeExt(e.target.value)}
+                            />
+                        </label>
+                    </form>
+                    <br />
+                    <hr />
+                    <SavePlot 
+                        exportDimensions={[this.state.exportWidth,this.state.exportHeight]}
+                        exportType={this.state.exportType}
+                        handleChangeExt={this.handleChangeExt}
+                        handleDimensionUpdate={this.handleDimensionUpdate}
+                    />
                 </Modal.Body>
                 <Modal.Footer>
                     <Button onClick={this.props.close}>Close</Button>
@@ -49,8 +129,8 @@ class ExportModal extends Component {
     }
 }
 
-
 ExportModal.propTypes = {
+    selected_cell_id: PropTypes.string,
     show: PropTypes.bool.isRequired,
     close: PropTypes.func.isRequired,
 }

--- a/frontend/src/js/components/modals/ExportModal.jsx
+++ b/frontend/src/js/components/modals/ExportModal.jsx
@@ -38,7 +38,7 @@ class ExportModal extends Component {
                     <TabBar tabs={this.state.tabs} selected_tab={this.state.selected_tab} switchTab={this.switchTab}/>
                     <hr/>
                     {
-                        this.state.selected_tab === 1 ? "Not yet implemented" : <SavePlot variables={this.props.variables} plots={this.props.plots} />
+                        this.state.selected_tab === 1 ? "Not yet implemented" : <SavePlot />
                     }
                 </Modal.Body>
                 <Modal.Footer>
@@ -53,9 +53,6 @@ class ExportModal extends Component {
 ExportModal.propTypes = {
     show: PropTypes.bool.isRequired,
     close: PropTypes.func.isRequired,
-    // Added for screenshot testing
-    plots: PropTypes.array,
-    variables: PropTypes.array,
 }
 
 export default ExportModal

--- a/frontend/src/js/components/modals/SavePlot/SavePlot.jsx
+++ b/frontend/src/js/components/modals/SavePlot/SavePlot.jsx
@@ -28,7 +28,7 @@ class SavePlot extends Component{
             // Update default dimensions to match current window size
             this.props.handleDimensionUpdate([this.canvasDiv.width,this.canvasDiv.height]);
             
-            this.canvasDiv.toBlob((blob)=>{
+            this.canvasDiv.toBlob((blob) => {
                 this.setState({img_url: URL.createObjectURL(blob)})
             });
         }
@@ -45,11 +45,13 @@ class SavePlot extends Component{
                 toast.warn("Enter a filename.", {position: toast.POSITION.BOTTOM_CENTER});
                 return;
             }
+
             var ext = fileName.substr(fileName.lastIndexOf('.') + 1);
 
             if(ext===fileName){
                 ext = "";// No extension was entered
             }
+
             switch(ext){
                 case "":
                     ext = this.props.exportType;
@@ -94,9 +96,7 @@ class SavePlot extends Component{
             let canvas = vcs.init(this.canvasDiv);
             
             canvas.plot(variable, graphicMethod, plotInfo.template).then((info) => {
-                console.log(this.props.exportDimensions);
                 canvas.screenshot(ext, true, false, fileName, this.props.exportDimensions[0], this.props.exportDimensions[1]).then((result, msg) => {
-                    console.log(this.props.exportDimensions);
                     console.log(msg);
                     if(result.success){
                         const { blob, type } = result;
@@ -107,7 +107,6 @@ class SavePlot extends Component{
                     } else {
                         console.log(result.msg);
                     }
-                    
                 }).catch((err) => {
                     console.log(err);
                     toast.error("Error occurred when saving plot.", {position: toast.POSITION.BOTTOM_CENTER});

--- a/frontend/src/js/components/modals/SavePlot/SavePlot.jsx
+++ b/frontend/src/js/components/modals/SavePlot/SavePlot.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { toast } from 'react-toastify'
-//import FileSaver from 'file-saver'
+import FileSaver from 'file-saver'
 import './SavePlot.scss'
 
 class SavePlot extends Component{
@@ -13,28 +13,146 @@ class SavePlot extends Component{
             img_url: "",
         }
         this.savePlot = this.savePlot.bind(this);
-        this.canvas = null;
+        this.canvasDiv = null;
     }
+
     /* istanbul ignore next */
     componentDidMount(){
-        let elements = document.querySelectorAll(`.cell-stack-top > #canvas_${this.props.selected_cell_id} > canvas`)
+        let elements = document.querySelectorAll(`.cell-stack-top > #canvas_${this.props.selected_cell_id} > canvas`);
         if(elements && elements.length > 0){
-            let canvas_el = elements[0];
-            this.canvas = vcs.init(canvas_el);
-            canvas_el.toBlob((blob)=>{
+            this.canvasDiv = elements[0];
+            
+            // this.canvas = vcs.init(canvas_el);
+            // this.canvas.plot(this.props.plots.plotVariables)
+
+            this.canvasDiv.toBlob((blob)=>{
                 this.blob = blob
                 this.setState({img_url: URL.createObjectURL(blob)})
-            })
+            });
+            /* vcs.creategraphicsmethod('boxfill', 'myboxfill').then((gm) => {
+                return this.canvas.plot(dataSpecs, this.props.plotGMs[index], plot.template).then(
+                    success => {
+                        return;
+                    },
+                    error => {
+                        this.canvas.close();
+                        delete this.canvas;
+                        this.canvas = vcs.init(this.div);
+                        if (error.data) {
+                            console.warn("Error while plotting: ", error);
+                            toast.error(error.data.exception, { position: toast.POSITION.BOTTOM_CENTER });
+                        } else {
+                            console.warn("Unknown error while plotting: ", error);
+                            toast.error("Error while plotting", { position: toast.POSITION.BOTTOM_CENTER });
+                        }
+                    }
+                );
+            });*/
         }
     }
     /* istanbul ignore next */
     savePlot(){
-        if(this.canvas){
-            console.log(this.canvas);
-            //FileSaver.saveAs(this.blob, this.state.name)
+        if(this.canvasDiv){
+
+            let canvas = vcs.init(document.getElementById(this.canvasDiv));
+            vcs.creategraphicsmethod('boxfill', 'tsetboxfill').then((gm) => {
+                console.log(gm);
+                return canvas.plot(console.log({uri: 'clt.nc',variable: this.props.variables[0],}, ['boxfill', 'myboxfill']));
+            }).then((r) => {
+                let renderer = r;
+                renderer.onImageReady(() => {
+                    console.log('Ready1');
+                });
+
+                // // what if we want to plot over the first plot
+                // // This seems to work just fine when uncommented, except for some
+                // // slight misalignment of the vector layer
+                // var dataSpec = [variables.u, variables.v];
+                // var rendererPromise2 = canvas.plot(dataSpec, ['vector', 'default']);
+                // rendererPromise2.then((r) => {
+                //   r.onImageReady(() => {
+                //     console.log('Ready2');
+                //   });
+                // });
+            });
+            
+            console.log(canvas);
+
+            console.log(this.props.selected_cell_id);
+            console.log(this.props.plots[0]);
+            console.log(this.props.plots[0]["graphics_method_parent"]);
+            console.log(this.props.plots[0]["graphics_method"]);
+            console.log(this.props.plots[0]["template"]);
+            console.log(this.props.plots[0]["variables"][0]);
+            console.log(this.props.variables);
+
+            /*
+            let renderPromise = this.canvas.plot(
+                {uri: 'clt.nc',variable: this.props.variables[0],},
+                [this.props.plots[0]["graphics_method_parent"],this.props.plots[0]["graphics_method"]],
+                this.props.plots[0]["template"]).then(() => {
+                success => {
+                    return;
+                },
+                error => {
+                    this.canvas.close();
+                    delete this.canvas;
+                    this.canvas = vcs.init(this.div);
+                    if (error.data) {
+                        console.warn("Error while generating save plot: ", error);
+                        toast.error(error.data.exception, { position: toast.POSITION.BOTTOM_CENTER });
+                    } else {
+                        console.warn("Unknown error while saving plot: ", error);
+                        toast.error("Error while plotting", { position: toast.POSITION.BOTTOM_CENTER });
+                    }
+                }
+            }).then((result) => {
+                console.log(result);
+            });
+
+            this.canvas.screenshot('pdf', true, false, null).then((result) => {
+                console.log('Got screenshot result:');
+                console.log(result);
+                const { blob, type } = result;
+                let pdfBlobUrl = URL.createObjectURL(blob);
+                var link = document.createElement("a");
+                link.href = pdfBlobUrl;
+                const fname = `image.${type}`;
+                link.download = fname;
+                link.innerHTML = `Click here to download ${fname}`;
+                document.body.appendChild(link);
+            });
+            this.canvas.screenshot('png', false, true, this.state.name, 1024, 768).then((result, msg) => {
+                console.log('Got screenshot result:');
+                console.log(result);
+                console.log(msg);
+                const { blob, type } = result;
+                console.log(type + " file was saved.")
+                pngBlobUrl = URL.createObjectURL(blob);
+            
+                var img = document.createElement("img");
+                img.classList.add("obj");
+                img.file = blob;
+                img.width = 200;
+                img.height = 176;
+            
+                var link = document.createElement("a");
+                link.href = pngBlobUrl;
+                const fname = `image.${type}`;
+                link.download = fname;
+                link.appendChild(img);
+                document.body.appendChild(link);
+            
+                var reader = new FileReader();
+                reader.onload = function(e) {
+                  img.src = e.target.result;
+                };
+                reader.readAsDataURL(blob);
+                FileSaver.saveAs(blob, this.state.name);
+            });*/
         }
         else{
-            toast.warn("No image available to save.", {position: toast.POSITION.BOTTOM_CENTER})
+            toast.warn("No image available to save.", {position: toast.POSITION.BOTTOM_CENTER});
         }
     }
 
@@ -76,6 +194,11 @@ SavePlot.propTypes = {
     onTryClose: PropTypes.func,
     show: PropTypes.bool,
     selected_cell_id: PropTypes.string,
+    // Added for save plot functionality:
+    plots: PropTypes.array,
+    variables: PropTypes.array,
+    plotVariables: PropTypes.array,
+    plotGMs: PropTypes.array,
 }
 
 export default connect(mapStateToProps, null)(SavePlot)

--- a/frontend/src/js/components/modals/SavePlot/SavePlot.jsx
+++ b/frontend/src/js/components/modals/SavePlot/SavePlot.jsx
@@ -68,7 +68,7 @@ class SavePlot extends Component{
             
             canvas.plot(variable, graphicMethod).then((info) => {
                 console.log(info);
-                canvas.screenshot(ext, true, false, fileName, 1024, 1024).then((result, msg) => {
+                canvas.screenshot(ext, true, false, fileName).then((result, msg) => {
                     console.log('Got screenshot result:');
                     console.log(result);
                     

--- a/frontend/src/js/components/modals/SavePlot/SavePlot.jsx
+++ b/frontend/src/js/components/modals/SavePlot/SavePlot.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { toast } from 'react-toastify'
-import FileSaver from 'file-saver'
+//import FileSaver from 'file-saver'
 import './SavePlot.scss'
 
 class SavePlot extends Component{
@@ -12,14 +12,16 @@ class SavePlot extends Component{
             name: "",
             img_url: "",
         }
-        this.savePlot = this.savePlot.bind(this)
+        this.savePlot = this.savePlot.bind(this);
+        this.canvas = null;
     }
     /* istanbul ignore next */
     componentDidMount(){
         let elements = document.querySelectorAll(`.cell-stack-top > #canvas_${this.props.selected_cell_id} > canvas`)
         if(elements && elements.length > 0){
-            let canvas = elements[0]
-            canvas.toBlob((blob)=>{
+            let canvas_el = elements[0];
+            this.canvas = vcs.init(canvas_el);
+            canvas_el.toBlob((blob)=>{
                 this.blob = blob
                 this.setState({img_url: URL.createObjectURL(blob)})
             })
@@ -27,8 +29,9 @@ class SavePlot extends Component{
     }
     /* istanbul ignore next */
     savePlot(){
-        if(this.blob){
-            FileSaver.saveAs(this.blob, this.state.name)
+        if(this.canvas){
+            console.log(this.canvas);
+            //FileSaver.saveAs(this.blob, this.state.name)
         }
         else{
             toast.warn("No image available to save.", {position: toast.POSITION.BOTTOM_CENTER})

--- a/frontend/src/js/models/Colormaps.js
+++ b/frontend/src/js/models/Colormaps.js
@@ -39,8 +39,9 @@ class ColormapModel extends BaseModel {
         }
         catch(e){
             if(e.name == "ReferenceError"){
+                
+                console.warn("Warning: vcs is not defined. Is the vcs server running?");
                 return $.get("getColormaps");
-                console.warn("Warning: vcs is not defined. Is the vcs server running?")
             }
             else{
                 throw e

--- a/frontend/test/mocha/components/Modals/ExportModalTest.jsx
+++ b/frontend/test/mocha/components/Modals/ExportModalTest.jsx
@@ -22,12 +22,4 @@ describe("ExportModalTest.jsx", function() {
         var export_modal = shallow(<ExportModal {...props} />);
         expect(export_modal).to.have.lengthOf(1);
     });
-
-    it("Switch tab sets correct state", () => {
-        const props = getProps();
-        var export_modal = shallow(<ExportModal {...props} />);
-        expect(export_modal.state().selected_tab).to.equal(0);
-        export_modal.instance().switchTab(1);
-        expect(export_modal.state().selected_tab).to.equal(1);
-    });
 });

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -47,7 +47,7 @@ if [[ $current_dir == */vcdat* ]]; then
     conda env remove -y -n ${CONDA_ENV}
 
     # Create a new one
-    conda create -y -n ${CONDA_ENV} -c cdat/label/nightly -c conda-forge -c cdat --file $current_dir/backend/requirements.txt
+    conda create -y -n ${CONDA_ENV} -c cdat/label/nightly -c conda-forge -c cdat --file $current_dir/backend/requirements.txt python=2
 
     source activate ${CONDA_ENV}
     cd frontend


### PR DESCRIPTION
The export plot functionality of vcdat has been overhauled and implemented. User can now export their selected plot as a png, pdf or svg. As the vcdat code is implemented currently, it allows the user to pass specified dimensions for the screenshot and the export is downloaded once the save button is pressed. To test functionality, click the 'export' button on the tools area in the top-left corner of vcdat. From there you can try saving plots of different types, sizes and names. Under the hood, a new vcs plot is made based on the current cell settings (graphics method, template etc.), the plot is made on a canvas which is then passed to vcs-js 'canvas.screenshot' function. Graphical issues may appear if user doesn't install mesalib, however mesalib is excluded by default because it slows down 3d renders in vcdat. There is also an issue with the pdf and svg files not using the user specified dimensions, and instead they use the current vcdat plot dimensions. The issue appears to be from the vcs-js side and once fixed should work correctly in vcdat.