### PR TITLE
Removed non-functional help tutorial buttons from template editor

### DIFF
--- a/conda/meta.yaml.in
+++ b/conda/meta.yaml.in
@@ -4,7 +4,7 @@ package:
 
 source:
   git_rev: @UVCDAT_BRANCH@
-  git_url: git://github.com/UV-CDAT/vcdat.git
+  git_url: git://github.com/CDAT/vcdat.git
 
 requirements:
   build:
@@ -24,4 +24,4 @@ build:
   noarch_python: true
 
 about:
-  home: http://github.com/UV-CDAT/vcdat
+  home: http://github.com/CDAT/vcdat

--- a/frontend/src/js/components/TemplateList.jsx
+++ b/frontend/src/js/components/TemplateList.jsx
@@ -13,7 +13,7 @@ import { toast } from 'react-toastify'
 function TemplateItem(props) {
     // This function is injected by the Dra
     return props.connectDragSource(
-        <li className={props.active ? "active" : ""} onClick={(e) => {props.selectTemplate(props.template)}}>
+        <li className={props.active ? "active" : ""} onClick={() => {props.selectTemplate(props.template)}}>
             <a>{props.template}</a>
         </li>
     );
@@ -159,7 +159,6 @@ class TemplateList extends Component {
                     </ul>
                 </div>
                 <TemplateEditor
-                    startTour={this.props.startTour}
                     show={this.state.showTemplateEditor}
                     close={/* istanbul ignore next */ () => this.setState({showTemplateEditor: false})}
                     template={this.state.template_data}
@@ -184,7 +183,6 @@ TemplateList.propTypes = {
     selectTemplate: PropTypes.func,
     updateTemplate: PropTypes.func,
     removeTemplate: PropTypes.func,
-    startTour: PropTypes.func,
 }
 
 export default TemplateList;

--- a/frontend/src/js/components/modals/TemplateEditor.jsx
+++ b/frontend/src/js/components/modals/TemplateEditor.jsx
@@ -59,15 +59,14 @@ class TemplateEditor extends Component {
             <Modal show={this.props.show} onHide={this.props.close}>
                 <div id='template-editor-main'>
                     <Modal.Header closeButton>
-                        <Modal.Title>Edit {template_name} &nbsp;
-                            <Button onClick={() => this.props.startTour(3)} className="help-button main-help btn btn-xs btn-default">
-                                <i className="glyphicon glyphicon-question-sign" />Help
-                            </Button>
-                        </Modal.Title>
+                        <Modal.Title>Edit {template_name} &nbsp;</Modal.Title>
                     </Modal.Header>
                     <Modal.Body>
                         {
-                            this.props.template === "loading" ? <div style={{display: "flex", justifyContent: "center"}}><span className="loading-spinner"></span></div>
+                            this.props.template === "loading" ? 
+                                <div style={{display: "flex", justifyContent: "center"}}>
+                                    <span className="loading-spinner"></span>
+                                </div>
                             : this.props.template === "error" ? 
                                 <div id="template-load-error">
                                     Error retrieving template data. Try another template, or restart vCDAT. 
@@ -94,7 +93,6 @@ class TemplateEditor extends Component {
 TemplateEditor.propTypes = {
     show: PropTypes.bool,
     close: PropTypes.func,
-    startTour: PropTypes.func,
     template: PropTypes.oneOfType([
         PropTypes.string, // valid states: "loading" or "error"
         PropTypes.object, // template is an object if loading was successfull

--- a/frontend/src/js/constants/Constants.js
+++ b/frontend/src/js/constants/Constants.js
@@ -207,7 +207,8 @@ const COLORMAP_STEPS = [
     },
     {
         title: 'Color Grid',
-        text: 'The colors and their respective index are listed here in order. Clicking on a cell will allow you to adjust the color (see next frame).'.concat(
+        text: 'The colors and their respective index are listed here in order. '.concat(
+            'Clicking on a cell will allow you to adjust the color (see next frame).',
             '<br />You can also select a range of cells by first clicking one cell and then holding shift and clicking on another.'
         ),
         selector: '#colormap-cells-container',
@@ -320,111 +321,10 @@ const LOAD_VARIABLE_STEPS = [
     },
 ];
 
-const TEMPLATE_EDITOR_STEPS = [
-    {
-        title: 'Template Editor Tour',
-        text: 'This will explain some of the main components of the template editor.',
-        selector: '#template-editor-main',
-        position: 'right',
-        type: 'click'
-    },
-    {
-        title: 'Template Preview',
-        text: 'This is a test.',
-        selector: '#joyride-test',
-        position: 'right',
-        type: 'click'
-    }
-];
-
-const BOXFILL_EDITOR_STEPS = [
-    {
-        title: 'Blend Colors',
-        text: "Clicking this button while having a cell range selected will interpolate the colors between the first cell".concat(
-            ' and the last cell of the selected range.<br />It is a fast way to create your own custom color map!'
-        ),
-        selector: '#btn-blend',
-        position: 'top',
-        type: 'click'
-    },
-    {
-        title: 'Save Colormap',
-        text: "Clicking this button will save your changes on the current colormap.<br />Note: ",
-        selector: '#btn-save-colormap',
-        position: 'top',
-        type: 'click'
-    },
-    {
-        title: 'Import and Export',
-        text: "Click this button if you wish to export your colormap as a JSON file for download, or to import a colormap JSON file.",
-        selector: '#btn-import-export',
-        position: 'top',
-        type: 'click'
-    },
-];
-
-const ISOFILL_EDITOR_STEPS = [
-    {
-        title: 'Blend Colors',
-        text: "Clicking this button while having a cell range selected will interpolate the colors between the first cell".concat(
-            ' and the last cell of the selected range.<br />It is a fast way to create your own custom color map!'
-        ),
-        selector: '#btn-blend',
-        position: 'top',
-        type: 'click'
-    },
-    {
-        title: 'Save Colormap',
-        text: "Clicking this button will save your changes on the current colormap.<br />Note: ",
-        selector: '#btn-save-colormap',
-        position: 'top',
-        type: 'click'
-    },
-    {
-        title: 'Import and Export',
-        text: "Click this button if you wish to export your colormap as a JSON file for download, or to import a colormap JSON file.",
-        selector: '#btn-import-export',
-        position: 'top',
-        type: 'click'
-    },
-];
-
-const ISOLINE_EDITOR_STEPS = [
-    {
-        title: 'Blend Colors',
-        text: "Clicking this button while having a cell range selected will interpolate the colors between the first cell".concat(
-            ' and the last cell of the selected range.<br />It is a fast way to create your own custom color map!'
-        ),
-        selector: '#btn-blend',
-        position: 'top',
-        type: 'click'
-    },
-    {
-        title: 'Save Colormap',
-        text: "Clicking this button will save your changes on the current colormap.<br />Note: ",
-        selector: '#btn-save-colormap',
-        position: 'top',
-        type: 'click'
-    },
-    {
-        title: 'Import and Export',
-        text: "Click this button if you wish to export your colormap as a JSON file for download, or to import a colormap JSON file.",
-        selector: '#btn-import-export',
-        position: 'top',
-        type: 'click'
-    },
-];
-
-
-
 export { JOYRIDE_STEPS };
 export { CALCULATOR_STEPS };
 export { COLORMAP_STEPS };
 export { LOAD_VARIABLE_STEPS };
-export { TEMPLATE_EDITOR_STEPS };
-export { BOXFILL_EDITOR_STEPS };
-export { ISOFILL_EDITOR_STEPS };
-export { ISOLINE_EDITOR_STEPS };
 export { ONE_VAR_PLOTS };
 export { TWO_VAR_PLOTS };
 export { BINARY_OPERATORS };

--- a/frontend/src/js/containers/AppContainer.jsx
+++ b/frontend/src/js/containers/AppContainer.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux'
 import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import { ToastContainer } from 'react-toastify'
-import { JOYRIDE_STEPS, CALCULATOR_STEPS, COLORMAP_STEPS, TEMPLATE_EDITOR_STEPS, LOAD_VARIABLE_STEPS } from '../constants/Constants.js'
+import { JOYRIDE_STEPS, CALCULATOR_STEPS, COLORMAP_STEPS, LOAD_VARIABLE_STEPS } from '../constants/Constants.js'
 import Joyride from 'react-joyride'
 import 'react-joyride/lib/react-joyride.scss'
 /* global jQuery */
@@ -33,7 +33,6 @@ class AppContainer extends Component{
                 case 1: STEPS = CALCULATOR_STEPS; break;
                 case 2: STEPS = COLORMAP_STEPS; break;
                 case 3: STEPS = LOAD_VARIABLE_STEPS; break;
-                case 4: STEPS = TEMPLATE_EDITOR_STEPS; break;
             }
 
             this.setState({jr_run: true, jr_steps: STEPS})

--- a/frontend/src/js/containers/LeftSideBar.jsx
+++ b/frontend/src/js/containers/LeftSideBar.jsx
@@ -34,7 +34,6 @@ class LeftSideBar extends Component {
                     selectTemplate={this.props.selectTemplate}
                     updateTemplate={this.props.updateTemplate}
                     removeTemplate={this.props.removeTemplate}
-                    startTour={this.props.startTour}
                 />
             </div>
         )
@@ -59,6 +58,11 @@ LeftSideBar.propTypes ={
     removeVariable: PropTypes.func,
     selectVariable: PropTypes.func,
     selected_variable: PropTypes.string,
+    updateGraphicsMethod: PropTypes.func,
+    default_methods: PropTypes.any,
+    selected_graphics_type: PropTypes.any,
+    selected_graphics_method: PropTypes.func,
+    selectGraphicsMethod: PropTypes.func,
     startTour: PropTypes.func,
     
 }


### PR DESCRIPTION
Just tidying up. Removed non-functional help tutorial buttons from template editor that were never implemented. Removed un-finished code associated with template editor tutorial. Updated github links in meta.yaml.in, and added proptype declarations that were missing in LeftSideBar.jsx.